### PR TITLE
Fix CPU diarizer import and add regression test

### DIFF
--- a/src/diaremot/pipeline/audio_pipeline_core.py
+++ b/src/diaremot/pipeline/audio_pipeline_core.py
@@ -869,7 +869,7 @@ class AudioAnalysisPipelineV2:
             self.diar = SpeakerDiarizer(self.diar_conf)
             if bool(cfg.get("cpu_diarizer", False)):
                 try:
-                    from cpu_optimized_diarizer import (
+                    from .cpu_optimized_diarizer import (
                         CPUOptimizationConfig,
                         CPUOptimizedSpeakerDiarizer,
                     )


### PR DESCRIPTION
## Summary
- switch the audio pipeline to use a package-relative import for the CPU diarizer wrapper
- extend the stageguard test scaffolding and add coverage that exercises the optimized CPU diarizer path when enabled

## Testing
- pytest tests/test_stageguard.py::test_cpu_diarizer_uses_optimized_wrapper -q

------
https://chatgpt.com/codex/tasks/task_e_68d895a24dbc832eb11b4b0d5f054bc2