### PR TITLE
Optimize checkpoint hash caching

### DIFF
--- a/src/diaremot/pipeline/audio_pipeline_core.py
+++ b/src/diaremot/pipeline/audio_pipeline_core.py
@@ -1200,11 +1200,16 @@ class AudioAnalysisPipelineV2:
                     duration_s=duration_s,
                     snr_db=float(getattr(health, "snr_db", 0.0)) if health else None,
                 )
+            audio_sha16 = _compute_audio_sha16(y)
+            if audio_sha16:
+                self.checkpoints.seed_file_hash(input_audio_path, audio_sha16)
+
             self.checkpoints.create_checkpoint(
                 input_audio_path,
                 ProcessingStage.AUDIO_PREPROCESSING,
                 {"sr": sr},
                 progress=5.0,
+                file_hash=audio_sha16,
             )
             # ========== 1b) Background SED (optional) ==========
             with StageGuard(self.corelog, self.stats, "background_sed"):
@@ -1231,7 +1236,6 @@ class AudioAnalysisPipelineV2:
                     )
 
             # Compute checkpoint signatures
-            audio_sha16 = _compute_audio_sha16(y)
             pp_sig = _compute_pp_signature(self.pp_conf)
             cache_dir = self.cache_root / audio_sha16
             cache_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_pipeline_checkpoint_manager.py
+++ b/tests/test_pipeline_checkpoint_manager.py
@@ -1,0 +1,62 @@
+import builtins
+from pathlib import Path
+
+import pytest
+
+from diaremot.pipeline import pipeline_checkpoint_system as pcs
+
+
+@pytest.fixture()
+def audio_file(tmp_path: Path) -> Path:
+    path = tmp_path / "sample.wav"
+    path.write_bytes(b"fake audio")
+    return path
+
+
+def _counting_open_factory(target: Path, original_open):
+    def _wrapped(file, mode="r", *args, **kwargs):
+        if Path(file) == target and "r" in mode and "b" in mode:
+            _wrapped.calls += 1
+        return original_open(file, mode, *args, **kwargs)
+
+    _wrapped.calls = 0
+    return _wrapped
+
+
+def test_checkpoint_manager_reuses_cached_hash(monkeypatch, tmp_path, audio_file):
+    manager = pcs.PipelineCheckpointManager(tmp_path / "checkpoints")
+    counting_open = _counting_open_factory(audio_file, builtins.open)
+    monkeypatch.setattr(pcs, "open", counting_open, raising=False)
+
+    manager.create_checkpoint(
+        str(audio_file),
+        pcs.ProcessingStage.TRANSCRIPTION,
+        {"payload": 1},
+        progress=10.0,
+    )
+    manager.create_checkpoint(
+        str(audio_file),
+        pcs.ProcessingStage.DIARIZATION,
+        {"payload": 2},
+        progress=20.0,
+    )
+
+    assert counting_open.calls == 1
+
+
+def test_seeded_hash_prevents_disk_reads(monkeypatch, tmp_path, audio_file):
+    manager = pcs.PipelineCheckpointManager(tmp_path / "checkpoints")
+    counting_open = _counting_open_factory(audio_file, builtins.open)
+    monkeypatch.setattr(pcs, "open", counting_open, raising=False)
+
+    seed = "0123456789abcdef0123456789abcdef"
+    manager.seed_file_hash(audio_file, seed)
+    manager.create_checkpoint(
+        str(audio_file),
+        pcs.ProcessingStage.TRANSCRIPTION,
+        {"payload": 3},
+        progress=5.0,
+        file_hash=seed,
+    )
+
+    assert counting_open.calls == 0


### PR DESCRIPTION
## Summary
- add a cache for pipeline checkpoint file hashes with an API for seeding precomputed values
- seed the checkpoint manager with the audio SHA value computed during preprocessing
- add pytest coverage that ensures hashes are read from disk only once when caching or seeding is used

## Testing
- pytest tests/test_pipeline_checkpoint_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68d895afc1a0832eac15d9edf757b67d