### PR TITLE
Adopt Pydantic config, restructure CLI domains, and standardize hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,14 @@ pip install -e .
 export DIAREMOT_MODEL_DIR=/opt/models   # or ./models locally
 
 # run via CLI (preferred)
-python -m diaremot.cli run --input samples/ --out outputs/run1
+python -m diaremot.cli asr run --input samples/ --out outputs/run1
 # or, if scripts are installed:
-# diaremot run --input samples/ --out outputs/run1
+# diaremot asr run --input samples/ --out outputs/run1
+# Backward-compatible aliases for ``diaremot run``/``resume`` remain available.
 
 # diagnostics
-python -m diaremot.cli diagnostics
-# or: diaremot-diagnostics
+python -m diaremot.cli system diagnostics
+# or: diaremot system diagnostics / diaremot-diagnostics
 ```
 
 Entrypoints are provided by `src/diaremot/cli.py` and `[project.scripts]` in `pyproject.toml`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "psutil==5.9.8",
     "click==8.1.7",
     "typer==0.9.0",
+    "pydantic==2.8.2",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,3 +51,4 @@ joblib==1.3.2
 psutil==5.9.8
 typer==0.9.0
 click==8.1.7
+pydantic==2.8.2

--- a/src/diaremot/README.md
+++ b/src/diaremot/README.md
@@ -31,13 +31,14 @@ pip install -e .
 export DIAREMOT_MODEL_DIR=/opt/models   # or ./models locally
 
 # run via CLI (preferred)
-python -m diaremot.cli run --input samples/ --out outputs/run1
+python -m diaremot.cli asr run --input samples/ --out outputs/run1
 # or, if scripts are installed:
-# diaremot run --input samples/ --out outputs/run1
+# diaremot asr run --input samples/ --out outputs/run1
+# Backward-compatible aliases for ``diaremot run``/``resume`` remain available.
 
 # diagnostics
-python -m diaremot.cli diagnostics
-# or: diaremot-diagnostics
+python -m diaremot.cli system diagnostics
+# or: diaremot system diagnostics / diaremot-diagnostics
 ```
 
 Entrypoints are provided by `src/diaremot/cli.py` and `[project.scripts]` in `pyproject.toml`.

--- a/src/diaremot/cli.py
+++ b/src/diaremot/cli.py
@@ -2,51 +2,31 @@
 
 from __future__ import annotations
 
+import csv
 import json
 from functools import lru_cache
 from importlib import import_module
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import typer
 
-app = typer.Typer(help="High level CLI wrapper for the DiaRemot audio pipeline.")
+from .pipeline.config import PipelineConfig
 
+app = typer.Typer(
+    help="""High level CLI wrapper for the DiaRemot audio pipeline.\n\nThe CLI is now organised into domain-centric groups. For example:\n\n  • diaremot asr run --input sample.wav --outdir outputs/run1\n  • diaremot vad debug --input sample.wav\n  • diaremot report gen --manifest outputs/run1/manifest.json""",
+    rich_markup_mode="markdown",
+)
+asr_app = typer.Typer(help="Automatic speech recognition, diarization and affect pipeline commands.")
+vad_app = typer.Typer(help="Voice activity detection tooling.")
+report_app = typer.Typer(help="Reporting and summary generation utilities.")
+system_app = typer.Typer(help="System level diagnostics and maintenance commands.")
 
-@lru_cache()
-def _core():
-    try:
-        from .pipeline import orchestrator as _orch
-        from .pipeline import config as _config
-    except ModuleNotFoundError:
-        try:
-            return import_module("diaremot.pipeline.audio_pipeline_core")
-        except ModuleNotFoundError:
-            return import_module("audio_pipeline_core")
-    else:
-        return SimpleNamespace(
-            build_pipeline_config=_config.build_pipeline_config,
-            diagnostics=_orch.diagnostics,
-            resume=_orch.resume,
-            run_pipeline=_orch.run_pipeline,
-        )
-
-
-def core_build_config(overrides: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-    return _core().build_pipeline_config(overrides)
-
-
-def core_diagnostics(*args: Any, **kwargs: Any) -> Dict[str, Any]:
-    return _core().diagnostics(*args, **kwargs)
-
-
-def core_resume(*args: Any, **kwargs: Any) -> Dict[str, Any]:
-    return _core().resume(*args, **kwargs)
-
-
-def core_run_pipeline(*args: Any, **kwargs: Any) -> Dict[str, Any]:
-    return _core().run_pipeline(*args, **kwargs)
+app.add_typer(asr_app, name="asr")
+app.add_typer(vad_app, name="vad")
+app.add_typer(report_app, name="report")
+app.add_typer(system_app, name="system")
 
 BUILTIN_PROFILES: Dict[str, Dict[str, Any]] = {
     "default": {},
@@ -69,6 +49,44 @@ BUILTIN_PROFILES: Dict[str, Dict[str, Any]] = {
         "ignore_tx_cache": False,
     },
 }
+
+_REPORT_FORMATS = {"pdf", "html"}
+
+
+@lru_cache()
+def _core():
+    try:
+        from .pipeline import orchestrator as _orch
+        from .pipeline import config as _config
+    except ModuleNotFoundError:
+        try:
+            return import_module("diaremot.pipeline.audio_pipeline_core")
+        except ModuleNotFoundError:
+            return import_module("audio_pipeline_core")
+    else:
+        return SimpleNamespace(
+            build_pipeline_config=_config.build_pipeline_config,
+            diagnostics=_orch.diagnostics,
+            resume=_orch.resume,
+            run_pipeline=_orch.run_pipeline,
+        )
+
+
+def core_build_config(overrides: Optional[Dict[str, Any]] = None) -> PipelineConfig:
+    data = _core().build_pipeline_config(overrides or {})
+    return PipelineConfig.model_validate(data)
+
+
+def core_diagnostics(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+    return _core().diagnostics(*args, **kwargs)
+
+
+def core_resume(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+    return _core().resume(*args, **kwargs)
+
+
+def core_run_pipeline(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+    return _core().run_pipeline(*args, **kwargs)
 
 
 def _load_profile(profile: Optional[str]) -> Dict[str, Any]:
@@ -102,8 +120,20 @@ def _normalise_path(value: Optional[Path]) -> Optional[str]:
     return str(value.expanduser().resolve())
 
 
-def _validate_assets(input_path: Path, output_dir: Path, config: Dict[str, Any]) -> None:
-    errors = []
+def _merge_configs(profile_overrides: Dict[str, Any], cli_overrides: Dict[str, Any]) -> Dict[str, Any]:
+    merged: Dict[str, Any] = dict(profile_overrides)
+    defaults = _default_config().model_dump(mode="python")
+    for key, value in cli_overrides.items():
+        if value is None:
+            continue
+        if key in profile_overrides and defaults.get(key) == value:
+            continue
+        merged[key] = value
+    return merged
+
+
+def _validate_assets(input_path: Path, output_dir: Path, config: PipelineConfig) -> None:
+    errors: List[str] = []
 
     if not input_path.exists():
         errors.append(f"Input file '{input_path}' does not exist.")
@@ -113,25 +143,25 @@ def _validate_assets(input_path: Path, output_dir: Path, config: Dict[str, Any])
     except Exception as exc:  # pragma: no cover - filesystem failure
         errors.append(f"Unable to create output directory '{output_dir}': {exc}")
 
-    registry_path = Path(config.get("registry_path", "speaker_registry.json"))
+    registry_path = config.registry_path.expanduser()
     try:
-        registry_path.expanduser().resolve().parent.mkdir(parents=True, exist_ok=True)
+        registry_path.resolve().parent.mkdir(parents=True, exist_ok=True)
     except Exception as exc:  # pragma: no cover - filesystem failure
         errors.append(f"Unable to prepare speaker registry directory: {exc}")
 
-    if str(config.get("affect_backend", "onnx")).lower() == "onnx":
-        for key in ("affect_text_model_dir", "affect_intent_model_dir"):
-            path_value = config.get(key)
-            if path_value:
-                resolved = Path(str(path_value)).expanduser()
-                if not resolved.exists():
-                    errors.append(
-                        f"Configured {key}='{path_value}' but the path is missing."
-                    )
+    if config.affect_backend == "onnx":
+        for key, path_value in {
+            "affect_text_model_dir": config.affect_text_model_dir,
+            "affect_intent_model_dir": config.affect_intent_model_dir,
+        }.items():
+            if path_value and not path_value.expanduser().exists():
+                errors.append(
+                    f"Configured {key}='{path_value}' but the path is missing."
+                )
 
-    cache_root = Path(config.get("cache_root", ".cache"))
+    cache_root = config.cache_root.expanduser()
     try:
-        cache_root.expanduser().resolve().mkdir(parents=True, exist_ok=True)
+        cache_root.resolve().mkdir(parents=True, exist_ok=True)
     except Exception as exc:  # pragma: no cover - filesystem failure
         errors.append(f"Unable to prepare cache directory '{cache_root}': {exc}")
 
@@ -139,26 +169,8 @@ def _validate_assets(input_path: Path, output_dir: Path, config: Dict[str, Any])
         raise typer.BadParameter("\n".join(errors))
 
 
-def _merge_configs(profile_overrides: Dict[str, Any], cli_overrides: Dict[str, Any]) -> Dict[str, Any]:
-    merged: Dict[str, Any] = dict(profile_overrides)
-    defaults = _default_config()
-    for key, value in cli_overrides.items():
-        if value is None:
-            continue
-        if (
-            key in profile_overrides
-            and key in defaults
-            and defaults.get(key) == value
-        ):
-            # Preserve profile-provided overrides when the CLI value merely reflects
-            # the default generated configuration.
-            continue
-        merged[key] = value
-    return merged
-
-
 @lru_cache()
-def _default_config() -> Dict[str, Any]:
+def _default_config() -> PipelineConfig:
     return core_build_config({})
 
 
@@ -175,6 +187,7 @@ def _common_options(**kwargs: Any) -> Dict[str, Any]:
         "ignore_tx_cache": kwargs.get("ignore_tx_cache"),
         "quiet": kwargs.get("quiet"),
         "disable_affect": kwargs.get("disable_affect"),
+        "affect_backend": kwargs.get("affect_backend"),
         "affect_text_model_dir": kwargs.get("affect_text_model_dir"),
         "affect_intent_model_dir": kwargs.get("affect_intent_model_dir"),
         "beam_size": kwargs.get("beam_size"),
@@ -190,6 +203,7 @@ def _common_options(**kwargs: Any) -> Dict[str, Any]:
         "vad_min_speech_sec": kwargs.get("vad_min_speech_sec"),
         "vad_min_silence_sec": kwargs.get("vad_min_silence_sec"),
         "vad_speech_pad_sec": kwargs.get("vad_speech_pad_sec"),
+        "vad_backend": kwargs.get("vad_backend"),
         "disable_energy_vad_fallback": kwargs.get("disable_energy_vad_fallback"),
         "energy_gate_db": kwargs.get("energy_gate_db"),
         "energy_hop_sec": kwargs.get("energy_hop_sec"),
@@ -214,8 +228,8 @@ def _common_options(**kwargs: Any) -> Dict[str, Any]:
     return overrides
 
 
-@app.command()
-def run(
+@asr_app.command("run")
+def asr_run(
     input: Path = typer.Option(..., "--input", "-i", help="Path to input audio file."),
     outdir: Path = typer.Option(..., "--outdir", "-o", help="Directory to write outputs."),
     profile: Optional[str] = typer.Option(
@@ -348,13 +362,20 @@ def run(
 
     profile_overrides = _load_profile(profile)
     merged = _merge_configs(profile_overrides, cli_overrides)
-    config = core_build_config(merged)
+
+    try:
+        config = core_build_config(merged)
+    except ValueError as exc:
+        raise typer.BadParameter(f"Configuration error: {exc}") from exc
 
     _validate_assets(input, outdir, config)
 
     try:
         manifest = core_run_pipeline(
-            str(input), str(outdir), config=config, clear_cache=clear_cache
+            str(input),
+            str(outdir),
+            config=config.model_dump(mode="python"),
+            clear_cache=clear_cache,
         )
     except Exception as exc:  # pragma: no cover - runtime failure
         typer.secho(f"Pipeline execution failed: {exc}", fg=typer.colors.RED)
@@ -363,8 +384,11 @@ def run(
     typer.echo(json.dumps(manifest, indent=2))
 
 
-@app.command()
-def resume(
+app.command("run")(asr_run)
+
+
+@asr_app.command("resume")
+def asr_resume(
     input: Path = typer.Option(..., "--input", "-i", help="Original input audio file."),
     outdir: Path = typer.Option(..., "--outdir", "-o", help="Output directory used in the previous run."),
     profile: Optional[str] = typer.Option(
@@ -485,12 +509,20 @@ def resume(
 
     profile_overrides = _load_profile(profile)
     merged = _merge_configs(profile_overrides, cli_overrides)
-    config = core_build_config(merged)
+
+    try:
+        config = core_build_config(merged)
+    except ValueError as exc:
+        raise typer.BadParameter(f"Configuration error: {exc}") from exc
 
     _validate_assets(input, outdir, config)
 
     try:
-        manifest = core_resume(str(input), str(outdir), config=config)
+        manifest = core_resume(
+            str(input),
+            str(outdir),
+            config=config.model_dump(mode="python"),
+        )
     except Exception as exc:  # pragma: no cover - runtime failure
         typer.secho(f"Pipeline resume failed: {exc}", fg=typer.colors.RED)
         raise typer.Exit(code=1) from exc
@@ -498,12 +530,18 @@ def resume(
     typer.echo(json.dumps(manifest, indent=2))
 
 
-@app.command()
-def diagnostics(strict: bool = typer.Option(False, help="Require minimum dependency versions.")):
+app.command("resume")(asr_resume)
+
+
+@system_app.command("diagnostics")
+def diagnostics(strict: bool = typer.Option(False, help="Require minimum dependency versions.")) -> None:
     """Run dependency diagnostics and emit a JSON summary."""
 
     result = core_diagnostics(require_versions=strict)
     typer.echo(json.dumps(result, indent=2))
+
+
+app.command("diagnostics")(diagnostics)
 
 
 def main_diagnostics() -> None:
@@ -512,7 +550,185 @@ def main_diagnostics() -> None:
     typer.run(diagnostics)
 
 
+def _load_segments_jsonl(path: Path) -> List[Dict[str, Any]]:
+    segments: List[Dict[str, Any]] = []
+    if not path.exists():
+        return segments
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                segments.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return segments
+
+
+def _load_segments_csv(path: Path) -> List[Dict[str, Any]]:
+    if not path.exists():
+        return []
+    with path.open("r", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        return [dict(row) for row in reader]
+
+
+def _load_speakers_csv(path: Path) -> List[Dict[str, Any]]:
+    if not path.exists():
+        return []
+    with path.open("r", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        return [dict(row) for row in reader]
+
+
+@report_app.command("gen")
+def report_gen(
+    manifest: Path = typer.Option(..., "--manifest", "-m", help="Manifest JSON from a pipeline run."),
+    outdir: Optional[Path] = typer.Option(None, "--outdir", help="Override output directory."),
+    format: List[str] = typer.Option(["pdf"], "--format", "-f", help="Formats to (re)generate: pdf or html."),
+    force: bool = typer.Option(False, "--force", help="Regenerate even if the target file already exists."),
+) -> None:
+    try:
+        manifest_data = json.loads(manifest.read_text())
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(f"Manifest '{manifest}' is not valid JSON: {exc}") from exc
+
+    outputs = manifest_data.get("outputs", {}) or {}
+    base_outdir = outdir or Path(manifest_data.get("out_dir", manifest.parent))
+    base_outdir = base_outdir.expanduser().resolve()
+    base_outdir.mkdir(parents=True, exist_ok=True)
+
+    segments: List[Dict[str, Any]] = []
+    segments_path = outputs.get("jsonl")
+    if segments_path:
+        segments = _load_segments_jsonl(Path(segments_path))
+    if not segments and outputs.get("csv"):
+        segments = _load_segments_csv(Path(outputs["csv"]))
+
+    if not segments:
+        raise typer.BadParameter("Manifest does not reference any segment outputs.")
+
+    speakers_summary: List[Dict[str, Any]] = []
+    speakers_path = outputs.get("speakers_summary")
+    if speakers_path:
+        speakers_summary = _load_speakers_csv(Path(speakers_path))
+
+    if not speakers_summary:
+        from .summaries.speakers_summary_builder import build_speakers_summary
+
+        speakers_summary = build_speakers_summary(segments, {}, {})
+
+    overlap_stats: Dict[str, Any] = {}
+    qc_path = outputs.get("qc_report")
+    if qc_path and Path(qc_path).exists():
+        try:
+            qc_data = json.loads(Path(qc_path).read_text())
+            overlap_stats = qc_data.get("overlap_stats", {}) or {}
+        except Exception:
+            overlap_stats = {}
+
+    formats = {fmt.lower() for fmt in format}
+    unknown_formats = formats - _REPORT_FORMATS
+    if unknown_formats:
+        raise typer.BadParameter(f"Unsupported report format(s): {', '.join(sorted(unknown_formats))}")
+
+    results: Dict[str, str] = {}
+    file_id = manifest_data.get("file_id") or base_outdir.name
+
+    if "pdf" in formats:
+        from .summaries.pdf_summary_generator import PDFSummaryGenerator
+
+        target = base_outdir / "summary.pdf"
+        if force or not target.exists():
+            pdf_path = PDFSummaryGenerator().render_to_pdf(
+                out_dir=str(base_outdir),
+                file_id=file_id,
+                segments=segments,
+                speakers_summary=speakers_summary,
+                overlap_stats=overlap_stats,
+            )
+        else:
+            pdf_path = str(target.resolve())
+        results["pdf"] = pdf_path
+
+    if "html" in formats:
+        from .summaries.html_summary_generator import HTMLSummaryGenerator
+
+        target = base_outdir / "summary.html"
+        if force or not target.exists():
+            html_path = HTMLSummaryGenerator().render_to_html(
+                out_dir=str(base_outdir),
+                file_id=file_id,
+                segments=segments,
+                speakers_summary=speakers_summary,
+                overlap_stats=overlap_stats,
+            )
+        else:
+            html_path = str(target.resolve())
+        results["html"] = html_path
+
+    typer.echo(json.dumps(results, indent=2))
+
+
+@vad_app.command("debug")
+def vad_debug(
+    input: Path = typer.Option(..., "--input", "-i", help="Audio file to analyse."),
+    threshold: float = typer.Option(0.30, "--threshold", help="Silero probability threshold."),
+    min_speech: float = typer.Option(0.8, "--min-speech", help="Minimum detected speech duration."),
+    min_silence: float = typer.Option(0.8, "--min-silence", help="Minimum detected silence duration."),
+    pad: float = typer.Option(0.2, "--pad", help="Padding added around VAD speech regions."),
+    backend: str = typer.Option("auto", "--backend", help="Backend to use: auto/torch/onnx."),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
+) -> None:
+    if not input.exists():
+        raise typer.BadParameter(f"Input file '{input}' does not exist.")
+
+    from .pipeline.speaker_diarization import DiarizationConfig, _SileroWrapper
+
+    import librosa
+    import numpy as np
+
+    cfg = DiarizationConfig(
+        target_sr=16000,
+        vad_threshold=threshold,
+        vad_min_speech_sec=min_speech,
+        vad_min_silence_sec=min_silence,
+        speech_pad_sec=pad,
+        vad_backend=backend,
+    )
+
+    wav, sr = librosa.load(str(input), sr=cfg.target_sr, mono=True)
+    wav = np.asarray(wav, dtype=np.float32)
+    detector = _SileroWrapper(cfg.vad_threshold, cfg.speech_pad_sec, backend=cfg.vad_backend)
+    speech_regions = detector.detect(wav, sr, cfg.vad_min_speech_sec, cfg.vad_min_silence_sec)
+
+    segments = [
+        {
+            "index": idx + 1,
+            "start": float(start),
+            "end": float(end),
+            "duration": float(max(0.0, end - start)),
+        }
+        for idx, (start, end) in enumerate(speech_regions)
+    ]
+
+    if json_output:
+        typer.echo(json.dumps({"segments": segments}, indent=2))
+        return
+
+    if not segments:
+        typer.echo("No speech detected by Silero VAD.")
+        return
+
+    total = sum(seg["duration"] for seg in segments)
+    typer.echo(f"Detected {len(segments)} speech region(s), total {total:.2f}s")
+    for seg in segments:
+        typer.echo(
+            f"#{seg['index']:02d} {seg['start']:.2f}s → {seg['end']:.2f}s "
+            f"(dur {seg['duration']:.2f}s)"
+        )
+
+
 if __name__ == "__main__":  # pragma: no cover
     app()
-
-

--- a/src/diaremot/io/onnx_utils.py
+++ b/src/diaremot/io/onnx_utils.py
@@ -2,21 +2,18 @@
 
 from __future__ import annotations
 
-import hashlib
 import logging
 from pathlib import Path
 from typing import Union
+
+from ..utils.hash import hash_file
 
 logger = logging.getLogger(__name__)
 
 
 def _check_sha256(path: Path, sha256: str) -> None:
     """Validate file integrity via SHA256."""
-    h = hashlib.sha256()
-    with path.open("rb") as f:
-        for chunk in iter(lambda: f.read(8192), b""):
-            h.update(chunk)
-    digest = h.hexdigest()
+    digest = hash_file(path, algo="sha256")
     if digest.lower() != sha256.lower():
         raise RuntimeError(f"SHA256 mismatch for {path}: {digest} != {sha256}")
 

--- a/src/diaremot/pipeline/config.py
+++ b/src/diaremot/pipeline/config.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from importlib import metadata as importlib_metadata
+from pathlib import Path
 from typing import Any, Iterator
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 try:  # pragma: no cover - packaging optional during tests
     from packaging.version import Version
@@ -12,52 +15,110 @@ except Exception:  # pragma: no cover - defensive fallback
 
 from .speaker_diarization import DiarizationConfig
 
-DEFAULT_PIPELINE_CONFIG: dict[str, Any] = {
-    "registry_path": "speaker_registry.json",
-    "ahc_distance_threshold": DiarizationConfig.ahc_distance_threshold,
-    "speaker_limit": None,
-    "whisper_model": "faster-whisper-tiny.en",
-    "asr_backend": "faster",
-    "compute_type": "float32",
-    "cpu_threads": 1,
-    "language": None,
-    "language_mode": "auto",
-    "ignore_tx_cache": False,
-    "quiet": False,
-    "disable_affect": False,
-    "affect_backend": "onnx",
-    "affect_text_model_dir": None,
-    "affect_intent_model_dir": None,
-    "beam_size": 1,
-    "temperature": 0.0,
-    "no_speech_threshold": 0.50,
-    "noise_reduction": False,
-    "enable_sed": True,
-    "auto_chunk_enabled": True,
-    "chunk_threshold_minutes": 30.0,
-    "chunk_size_minutes": 20.0,
-    "chunk_overlap_seconds": 30.0,
-    "vad_threshold": 0.30,
-    "vad_min_speech_sec": 0.8,
-    "vad_min_silence_sec": 0.8,
-    "vad_speech_pad_sec": 0.2,
-    "vad_backend": "auto",
-    "disable_energy_vad_fallback": False,
-    "energy_gate_db": -33.0,
-    "energy_hop_sec": 0.01,
-    "max_asr_window_sec": 480,
-    "segment_timeout_sec": 300.0,
-    "batch_timeout_sec": 1200.0,
-    "cpu_diarizer": False,
-    "validate_dependencies": False,
-    "strict_dependency_versions": False,
-    "cache_root": ".cache",
-    "cache_roots": [],
-    "log_dir": "logs",
-    "checkpoint_dir": "checkpoints",
-    "target_sr": 16000,
-    "loudness_mode": "asr",
-}
+
+class PipelineConfig(BaseModel):
+    """Validated configuration for the end-to-end pipeline."""
+
+    model_config = ConfigDict(extra="forbid", validate_assignment=True)
+
+    registry_path: Path = Field(default=Path("speaker_registry.json"))
+    ahc_distance_threshold: float = Field(default=DiarizationConfig.ahc_distance_threshold, ge=0.0)
+    speaker_limit: int | None = Field(default=None, ge=1)
+    whisper_model: str = Field(default="faster-whisper-tiny.en")
+    asr_backend: str = Field(default="faster")
+    compute_type: str = Field(default="float32")
+    cpu_threads: int = Field(default=1, ge=1)
+    language: str | None = None
+    language_mode: str = Field(default="auto")
+    ignore_tx_cache: bool = False
+    quiet: bool = False
+    disable_affect: bool = False
+    affect_backend: str = Field(default="onnx")
+    affect_text_model_dir: Path | None = None
+    affect_intent_model_dir: Path | None = None
+    beam_size: int = Field(default=1, ge=1)
+    temperature: float = Field(default=0.0, ge=0.0, le=1.0)
+    no_speech_threshold: float = Field(default=0.50, ge=0.0, le=1.0)
+    noise_reduction: bool = False
+    enable_sed: bool = True
+    auto_chunk_enabled: bool = True
+    chunk_threshold_minutes: float = Field(default=30.0, gt=0.0)
+    chunk_size_minutes: float = Field(default=20.0, gt=0.0)
+    chunk_overlap_seconds: float = Field(default=30.0, ge=0.0)
+    vad_threshold: float = Field(default=0.30, ge=0.0, le=1.0)
+    vad_min_speech_sec: float = Field(default=0.8, ge=0.0)
+    vad_min_silence_sec: float = Field(default=0.8, ge=0.0)
+    vad_speech_pad_sec: float = Field(default=0.2, ge=0.0)
+    vad_backend: str = Field(default="auto")
+    disable_energy_vad_fallback: bool = False
+    energy_gate_db: float = Field(default=-33.0)
+    energy_hop_sec: float = Field(default=0.01, gt=0.0)
+    max_asr_window_sec: int = Field(default=480, gt=0)
+    segment_timeout_sec: float = Field(default=300.0, gt=0.0)
+    batch_timeout_sec: float = Field(default=1200.0, gt=0.0)
+    cpu_diarizer: bool = False
+    validate_dependencies: bool = False
+    strict_dependency_versions: bool = False
+    cache_root: Path = Field(default=Path(".cache"))
+    cache_roots: list[Path] = Field(default_factory=list)
+    log_dir: Path = Field(default=Path("logs"))
+    checkpoint_dir: Path = Field(default=Path("checkpoints"))
+    target_sr: int = Field(default=16000, gt=0)
+    loudness_mode: str = Field(default="asr")
+    run_id: str | None = None
+    text_emotion_model: str | None = None
+    intent_labels: list[str] | None = None
+
+    @field_validator("affect_backend", "asr_backend", "vad_backend", mode="before")
+    @classmethod
+    def _lower_str(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return value.lower()
+        return value
+
+    @field_validator("affect_backend")
+    @classmethod
+    def _validate_affect_backend(cls, value: str) -> str:
+        allowed = {"auto", "onnx", "torch"}
+        if value not in allowed:
+            raise ValueError(f"affect_backend must be one of {sorted(allowed)}")
+        return value
+
+    @field_validator("vad_backend")
+    @classmethod
+    def _validate_vad_backend(cls, value: str) -> str:
+        allowed = {"auto", "onnx", "torch"}
+        if value not in allowed:
+            raise ValueError(f"vad_backend must be one of {sorted(allowed)}")
+        return value
+
+    @field_validator("loudness_mode")
+    @classmethod
+    def _validate_loudness_mode(cls, value: str) -> str:
+        allowed = {"asr", "broadcast"}
+        if value not in allowed:
+            raise ValueError(f"loudness_mode must be one of {sorted(allowed)}")
+        return value
+
+    @field_validator("cache_roots", mode="before")
+    @classmethod
+    def _coerce_cache_roots(cls, value: Any) -> Any:
+        if value is None:
+            return []
+        if isinstance(value, (str, Path)):
+            return [value]
+        return value
+
+    @model_validator(mode="after")
+    def _validate_chunking(self) -> "PipelineConfig":
+        if self.chunk_size_minutes * 60.0 <= self.chunk_overlap_seconds:
+            raise ValueError("chunk_overlap_seconds must be smaller than chunk_size_minutes * 60")
+        if self.chunk_threshold_minutes < self.chunk_size_minutes:
+            raise ValueError("chunk_threshold_minutes must be >= chunk_size_minutes")
+        return self
+
+
+DEFAULT_PIPELINE_CONFIG: dict[str, Any] = PipelineConfig().model_dump(mode="python")
 
 CORE_DEPENDENCY_REQUIREMENTS: dict[str, str] = {
     "numpy": "1.24",
@@ -75,6 +136,7 @@ CORE_DEPENDENCY_REQUIREMENTS: dict[str, str] = {
 __all__ = [
     "DEFAULT_PIPELINE_CONFIG",
     "CORE_DEPENDENCY_REQUIREMENTS",
+    "PipelineConfig",
     "build_pipeline_config",
     "verify_dependencies",
     "diagnostics",
@@ -82,18 +144,29 @@ __all__ = [
 ]
 
 
-def build_pipeline_config(overrides: dict[str, Any] | None = None) -> dict[str, Any]:
-    """Return a pipeline configuration merged with overrides."""
+def build_pipeline_config(overrides: dict[str, Any] | PipelineConfig | None = None) -> dict[str, Any]:
+    """Return a validated pipeline configuration merged with overrides."""
 
-    config = dict(DEFAULT_PIPELINE_CONFIG)
-    if overrides:
-        for key, value in overrides.items():
-            if key not in DEFAULT_PIPELINE_CONFIG and value is None:
-                # Skip unknown keys explicitly requesting default behaviour
-                continue
-            if value is not None or key in config:
-                config[key] = value
-    return config
+    if isinstance(overrides, PipelineConfig):
+        return overrides.model_dump(mode="python")
+
+    base = PipelineConfig()
+    if not overrides:
+        return base.model_dump(mode="python")
+
+    merged: dict[str, Any] = base.model_dump(mode="python")
+    for key, value in overrides.items():
+        if key not in merged:
+            raise ValueError(f"Unknown configuration key: {key}")
+        if value is None:
+            continue
+        merged[key] = value
+
+    try:
+        validated = PipelineConfig.model_validate(merged)
+    except ValidationError as exc:  # pragma: no cover - surface readable error upstream
+        raise ValueError(str(exc)) from exc
+    return validated.model_dump(mode="python")
 
 
 def _iter_dependency_status() -> Iterator[tuple[str, str, Any, str | None, Exception | None, Exception | None]]:

--- a/src/diaremot/pipeline/logging_utils.py
+++ b/src/diaremot/pipeline/logging_utils.py
@@ -163,7 +163,7 @@ class StageGuard(AbstractContextManager["StageGuard"]):
 
         if exc:
             known_nonfatal = self._is_known_nonfatal(exc)
-            trace_hash = hashlib.blake2b(
+            trace_hash = hashlib.blake2s(
                 f"{self.stage}:{type(exc).__name__}".encode(), digest_size=8
             ).hexdigest()
             self.corelog.event(

--- a/src/diaremot/pipeline/pipeline_checkpoint_system.py
+++ b/src/diaremot/pipeline/pipeline_checkpoint_system.py
@@ -6,7 +6,6 @@ Handles incremental saves, resume functionality, and stage-based progress tracki
 
 import json
 import pickle
-import hashlib
 import threading
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple, Union
@@ -14,6 +13,8 @@ from datetime import datetime
 from dataclasses import dataclass, asdict
 from enum import Enum
 import logging
+
+from ..utils.hash import hash_file
 
 
 class ProcessingStage(Enum):
@@ -120,12 +121,8 @@ class PipelineCheckpointManager:
             if not file_path.exists():
                 return ""
 
-            hash_md5 = hashlib.md5()
-            with open(file_path, "rb") as f:
-                for chunk in iter(lambda: f.read(4096), b""):
-                    hash_md5.update(chunk)
-
-            normalized = self._normalize_hash_value(hash_md5.hexdigest())
+            digest = hash_file(file_path)
+            normalized = self._normalize_hash_value(digest)
             self._hash_cache[key] = normalized
             return normalized
 

--- a/src/diaremot/pipeline/transcription_module.py
+++ b/src/diaremot/pipeline/transcription_module.py
@@ -1423,7 +1423,7 @@ def estimate_snr_db(audio: np.ndarray) -> float:
         return float("nan")
 
     # Create hash for caching
-    audio_hash = hashlib.md5(audio.tobytes()).hexdigest()[:16]
+    audio_hash = hashlib.blake2s(audio.tobytes()).hexdigest()[:16]
 
     try:
         # Fast SNR estimation

--- a/src/diaremot/utils/__init__.py
+++ b/src/diaremot/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for DiaRemot."""
+
+from .hash import hash_file
+
+__all__ = ["hash_file"]

--- a/src/diaremot/utils/hash.py
+++ b/src/diaremot/utils/hash.py
@@ -1,0 +1,49 @@
+"""Hash utilities with a consistent BLAKE2s default."""
+
+from __future__ import annotations
+
+from hashlib import blake2s, new
+from pathlib import Path
+from typing import Iterable, Union
+
+
+def _iter_chunks(handle, chunk_size: int) -> Iterable[bytes]:
+    while True:
+        chunk = handle.read(chunk_size)
+        if not chunk:
+            break
+        yield chunk
+
+
+def hash_file(
+    path: Union[str, Path],
+    *,
+    algo: str = "blake2s",
+    chunk_size: int = 8192,
+    digest_size: int | None = None,
+) -> str:
+    """Return the hexadecimal digest for ``path`` using ``algo``.
+
+    The default algorithm is **BLAKE2s** to provide modern security with
+    excellent CPU performance. ``algo`` may be any algorithm accepted by
+    :func:`hashlib.new`.
+    """
+
+    file_path = Path(path)
+    if not file_path.exists():
+        raise FileNotFoundError(file_path)
+
+    if algo.lower() == "blake2s":
+        hasher = blake2s(digest_size=digest_size or blake2s().digest_size)
+    else:
+        hasher = new(algo)
+
+    with file_path.open("rb") as handle:
+        for chunk in _iter_chunks(handle, chunk_size):
+            hasher.update(chunk)
+
+    return hasher.hexdigest()
+
+
+__all__ = ["hash_file"]
+

--- a/tests/test_pipeline_config_module.py
+++ b/tests/test_pipeline_config_module.py
@@ -5,15 +5,20 @@ from typing import Iterator, Tuple
 import pytest
 
 from diaremot.pipeline import config as config_mod
-from diaremot.pipeline.config import build_pipeline_config
+from diaremot.pipeline.config import PipelineConfig, build_pipeline_config
 
 
-def test_build_pipeline_config_merges_and_skips_none() -> None:
-    overrides = {"beam_size": 4, "speaker_limit": None, "unknown": None}
+def test_build_pipeline_config_merges_and_validates() -> None:
+    overrides = {"beam_size": 4, "speaker_limit": None}
     merged = build_pipeline_config(overrides)
     assert merged["beam_size"] == 4
-    assert "speaker_limit" in merged  # existing keys preserved even when None
-    assert "unknown" not in merged
+    assert merged["speaker_limit"] is None
+
+    with pytest.raises(ValueError):
+        build_pipeline_config({"unknown": 1})
+
+    cfg = PipelineConfig(beam_size=2)
+    assert build_pipeline_config(cfg)["beam_size"] == 2
 
 
 def test_dependency_summary_handles_import_errors(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- introduce a PipelineConfig Pydantic model with validation and strict override handling
- reorganize the Typer CLI into domain subcommands (asr, vad, report, system) with new utilities
- add a reusable hash_file helper and switch hashing to BLAKE2s across the pipeline
- refresh documentation and tests to cover the new workflow

## Testing
- pytest tests/test_pipeline_config_module.py tests/test_run_pipeline_shim.py tests/test_pipeline_cli_entry_module.py

------
https://chatgpt.com/codex/tasks/task_e_68d99d7a0580832eba13f784a0bb8c08