### PR TITLE
Refresh documentation and dependency manifests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,28 +1,32 @@
 # AGENTS.md — Build / Run / Test (Codex)
 
 ## Setup
-- **Setup script**: `./setup.sh`  (cold container)
-- **Maintenance**: `./maintenance.sh` (warm cache)
-- **Python**: 3.11 (repo supports 3.9–3.11 per pins)
+- **Setup script**: `./setup.sh` (creates venv, installs requirements, stages models)
+- **Maintenance**: `./maintenance.sh` (warm container health + model check)
+- **Python**: 3.11 recommended (repo pins support 3.9–3.11)
+- Ensure `ffmpeg` is available on PATH for audio decoding and chunking.
 
-## Run — choose ONE and delete the rest
+## Run
 ```bash
-# Preferred: CLI
-python -m diaremot.cli run --input "samples/" --out "outputs/run1"
+# Preferred Typer CLI group (ASR + diarization + affect)
+python -m diaremot.cli asr run --input "data/sample.wav" --outdir "outputs/run1"
 
-# If console scripts are installed:
-# diaremot run --input "samples/" --out "outputs/run1"
+# Console-script entrypoint (after editable install)
+diaremot asr run --input "data/sample.wav" --outdir "outputs/run1"
 
-# Alternate (legacy module entry if you call it directly):
-# python -m diaremot.pipeline.run_pipeline --input "samples/" --out "outputs/run1"
+# Resume using cached checkpoints
+diaremot asr resume --input "data/sample.wav" --outdir "outputs/run1"
+
+# Regenerate summaries without inference
+diaremot report gen --manifest "outputs/run1/manifest.json" --format pdf --format html
 ```
 Diagnostics:
 ```bash
-python -m diaremot.cli diagnostics
-# or: diaremot-diagnostics
+python -m diaremot.cli system diagnostics --strict
+# or: diaremot system diagnostics --strict / diaremot-diagnostics --strict
 ```
 
 ## Expectations
-- Models present under `$DIAREMOT_MODEL_DIR` (default `/opt/models`) per README.
-- Agent has **no internet**; all fetching is done in `setup.sh`.
-- On failure, exit non‑zero.
+- Models live under `$DIAREMOT_MODEL_DIR` (default `/opt/models`) as described in `README.md`.
+- Agent runtime has **no internet**; all model fetching must happen in `setup.sh`.
+- Exit with non-zero status on failure.

--- a/README.md
+++ b/README.md
@@ -1,97 +1,153 @@
-# DiaRemot — CPU‑Only Speech + Affect Pipeline (Codex‑Ready)
+# DiaRemot — CPU-Only Speech Intelligence Pipeline
 
-This project runs **on CPU** and produces a diarized transcript with per‑segment affect:
-- **ASR**: Faster‑Whisper tiny.en (CT2)
-- **Diarization**: Silero VAD (ONNX) + ECAPA‑TDNN embeddings (ONNX)
-- **SED**: PANNs (ONNX) + labels CSV
-- **SER**: 8‑class speech emotion (INT8/FP32 ONNX)
-- **Text emotion**: GoEmotions (ONNX)
-- **Intent/zero‑shot**: BART (ONNX classifier)
+DiaRemot is a production-oriented **speech intelligence stack that runs fully on CPU**. It ingests long-form recordings and produces:
 
-Everything is wired for **OpenAI Codex Cloud**: reproducible container, cached models, and no Windows‑only paths.
+- **Diarized transcripts** powered by Faster-Whisper with Silero VAD + ECAPA-TDNN diarization.
+- **Affect enrichment**: acoustic emotion (SER), text emotion (GoEmotions), voice-quality metrics, and custom intent classification.
+- **Sound event detection** using PANNs for background context.
+- **Actionable summaries**: HTML/PDF briefings, CSV rollups, JSONL transcripts, QC health diagnostics, and an extensible manifest describing every artefact.
+
+The repository is tuned for deterministic execution inside the OpenAI Codex environment (no GPU, no internet at runtime) and mirrors the local developer workflow.
 
 ---
 
-## Quickstart (local or Codex shell)
+## 1. Requirements at a Glance
+
+| Requirement | Notes |
+| --- | --- |
+| Python | 3.9–3.11 supported (3.11 recommended). |
+| CPU | x86_64 with AVX2 for Torch/CT2 wheels from the PyTorch CPU index. |
+| System tools | `ffmpeg` for decoding compressed audio and chunk extraction. |
+| Models | Pre-packaged ONNX/CT2 assets staged under `$DIAREMOT_MODEL_DIR` (defaults to `/opt/models`). See [Model Layout](#3-model-layout).
+| Disk | ~5 GB for models + temporary cache (`.cache/`). |
+
+Use `setup.sh` to bootstrap a Codex-compatible environment end-to-end (venv, requirements, model download, import checks). Run `maintenance.sh` in warm containers to re-validate model presence and imports.
+
+---
+
+## 2. Quickstart
 
 ```bash
-# Python 3.11 recommended (3.9–3.11 supported by your repo pins)
-python -V
-
-# venv
+# Python environment
 python -m venv .venv
-. .venv/bin/activate  # Windows: .venv\Scripts\activate
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+python -m pip install -U pip setuptools wheel
+python -m pip install -r requirements.txt
+python -m pip install -e .
 
-# install (uses your repo's requirements.txt with CPU torch index)
-pip install -U pip wheel setuptools
-pip install -r requirements.txt
-pip install -e .
+# Model staging (defaults to /opt/models)
+export DIAREMOT_MODEL_DIR=/opt/models  # or ./models if you prefer a local path
+# Populate the directory using setup.sh, a release models.zip, or manual sync.
 
-# models base dir
-export DIAREMOT_MODEL_DIR=/opt/models   # or ./models locally
+# Run a job (ASR + diarization + affect)
+diaremot asr run --input data/sample.wav --outdir outputs/sample_run
+# Equivalent module form if console scripts are unavailable:
+python -m diaremot.cli asr run --input data/sample.wav --outdir outputs/sample_run
 
-# run via CLI (preferred)
-python -m diaremot.cli asr run --input samples/ --out outputs/run1
-# or, if scripts are installed:
-# diaremot asr run --input samples/ --out outputs/run1
-# Backward-compatible aliases for ``diaremot run``/``resume`` remain available.
+# Resume a partially completed run
+diaremot asr resume --input data/sample.wav --outdir outputs/sample_run
 
-# diagnostics
-python -m diaremot.cli system diagnostics
-# or: diaremot system diagnostics / diaremot-diagnostics
+# Diagnostics and dependency health (includes ffmpeg + model checks)
+diaremot system diagnostics --strict
+
+# Regenerate summaries without re-running inference
+diaremot report gen --manifest outputs/sample_run/manifest.json --format pdf --format html
 ```
 
-Entrypoints are provided by `src/diaremot/cli.py` and `[project.scripts]` in `pyproject.toml`.
-`run_pipeline` and `resume` are also proxied through the CLI.
+Codex agents should call `python -m diaremot.cli asr run ...` after executing `setup.sh`. Warm-container maintenance uses `./maintenance.sh`.
 
 ---
 
-## Models (single source of truth)
+## 3. Model Layout
 
-All model files live under **`$DIAREMOT_MODEL_DIR`** (default `/opt/models`). Layout must be:
+The pipeline expects the following structure under `$DIAREMOT_MODEL_DIR` (default `/opt/models`):
 
 ```
-{MODEL_DIR}/silero_vad.onnx
-{MODEL_DIR}/ecapa_onnx/ecapa_tdnn.onnx
-{MODEL_DIR}/panns/model.onnx
-{MODEL_DIR}/panns/class_labels_indices.csv
-{MODEL_DIR}/goemotions-onnx/model.onnx
-{MODEL_DIR}/ser8-onnx/model.onnx        # or model.int8.onnx
-{MODEL_DIR}/faster-whisper-tiny.en/model.bin
-{MODEL_DIR}/bart/model_uint8.onnx       # or model.onnx
-# BART tokenizer assets (required for offline)
-{MODEL_DIR}/bart/tokenizer.json         # or merges.txt + vocab.json
-{MODEL_DIR}/bart/tokenizer_config.json
-{MODEL_DIR}/bart/special_tokens_map.json
-{MODEL_DIR}/bart/config.json
+silero_vad.onnx
+ecapa_onnx/ecapa_tdnn.onnx
+panns/model.onnx
+panns/class_labels_indices.csv
+goemotions-onnx/model.onnx
+ser8-onnx/model.int8.onnx  # FP32 fallback: ser8-onnx/model.onnx
+faster-whisper-tiny.en/model.bin
+bart/model_uint8.onnx      # FP32 fallback: bart/model.onnx
+bart/tokenizer.json        # or merges.txt + vocab.json
+bart/tokenizer_config.json
+bart/special_tokens_map.json
+bart/config.json
 ```
 
 Ship models via one of:
-1. **Repo**: include `models/` or `models.zip` in repo root.
-2. **Release**: upload `models.zip` as a GitHub Release asset; `setup.sh` can download it.
-3. **Custom host**: download during `setup.sh` with checksum verification.
 
-**Codex note:** models persist in the warm container cache (~12h).
+1. **Bundled assets** – commit `models/` or `models.zip` to the repo.
+2. **Release download** – host `models.zip` and configure `setup.sh` to fetch + checksum verify.
+3. **Custom staging** – populate the directory prior to running the CLI.
 
----
-
-## Environment variables
-
-- `DIAREMOT_MODEL_DIR` (default `/opt/models`) — base directory above
-- `OMP_NUM_THREADS=1` — avoid CPU oversubscription
-- `TOKENIZERS_PARALLELISM=false` — silence HF tokenizer parallelism
-- `HF_HOME=/opt/cache/hf` — Hugging Face cache path (optional)
-
-Optional (for release download in setup):
-- `MODEL_RELEASE_URL` — direct URL to `models.zip`
-- `MODEL_RELEASE_SHA256` — SHA256 for integrity check
+`maintenance.sh` validates that either the INT8 or FP32 SER/BART weights are present alongside tokenizer assets.
 
 ---
 
-## Codex Cloud settings
+## 4. CLI Surface
 
-- **Base image**: `universal` (Python 3.11)
-- **Setup script**: `./setup.sh` — installs deps, stages `models/` into `/opt/models`
-- **Maintenance**: `./maintenance.sh` — quick health/import check
-- **Internet**: Agent **OFF** (deterministic). Setup can fetch if needed.
-- **AGENTS.md** shows concrete run commands via the CLI.
+The Typer-based CLI exposes domain-specific groups:
+
+### `diaremot asr`
+- `run` – complete ASR + diarization + affect pipeline. Supports profiles (`--profile fast|accurate|offline`), Faster-Whisper backend selection, Silero VAD tuning, energy-VAD fallback control, automatic chunking for long files, noise reduction, and affect backend overrides.
+- `resume` – pick up from checkpoints in `--outdir` (retains cached diarization/transcription artefacts).
+
+Key options map directly onto the validated [`PipelineConfig`](src/diaremot/pipeline/config.py): chunk sizing, CPU threading, cache roots, ASR timeouts, SED enablement, and affect model directories.
+
+### `diaremot vad`
+- `debug` – lightweight Silero VAD inspection with JSON output for troubleshooting thresholds.
+
+### `diaremot report`
+- `gen` – rebuild HTML/PDF summaries from a manifest, optionally synthesizing speaker summaries if CSV rollups are absent.
+
+### `diaremot system`
+- `diagnostics` – dependency/model health checks (`--strict` enforces version minimums) and ffmpeg availability reporting.
+
+The root command preserves `diaremot run ...` for backwards compatibility, delegating to `asr run`.
+
+---
+
+## 5. Outputs
+
+Each run writes a manifest (`manifest.json`) with the canonical list of artefacts:
+
+- `diarized_transcript_with_emotion.csv` and `segments.jsonl` for per-segment metadata (speaker, timestamps, text, SER/GoEmotions scores, voice-quality metrics, intent tags, VAD confidence, etc.).
+- `timeline.csv` for diarization-only consumption.
+- `summary.html` / `summary.pdf` built from the HTML/PDF generators.
+- `speakers_summary.csv` aggregating per-speaker statistics when available.
+- `qc_report.json` containing stage timings, dependency health, audio quality metrics, and summary voice-quality statistics.
+- `speaker_registry.json` (path surfaced in the manifest) for persistent speaker embeddings.
+
+The pipeline also persists intermediate checkpoints under `checkpoints/` and logs in `logs/` to support resume and audit flows.
+
+---
+
+## 6. Configuration & Environment
+
+Key environment variables:
+
+- `DIAREMOT_MODEL_DIR` – override model root (default `/opt/models`).
+- `OMP_NUM_THREADS=1` – recommended to prevent CPU oversubscription.
+- `TOKENIZERS_PARALLELISM=false` – silences Hugging Face tokenizer warnings.
+- `HF_HOME`, `HUGGINGFACE_HUB_CACHE`, `TRANSFORMERS_CACHE`, `TORCH_HOME`, `XDG_CACHE_HOME` – automatically pointed at `.cache/` for offline determinism.
+
+`PipelineConfig` supports additional tuning such as `auto_chunk_enabled`, `chunk_threshold_minutes`, `cache_roots`, `noise_reduction`, and `cpu_diarizer`. See [`src/diaremot/pipeline/config.py`](src/diaremot/pipeline/config.py) for exhaustive fields and validation rules.
+
+---
+
+## 7. Development Workflow
+
+- Run unit tests with `pytest -q`.
+- Use `python -m diaremot.cli system diagnostics --strict` to confirm dependency health before shipping new builds.
+- The codebase lives under `src/diaremot/` (Typer CLI, pipeline orchestrator, affect modules, summaries). Tests reside in `tests/` and stub third-party components (e.g., ReportLab) for offline CI.
+
+When contributing, update this README, `requirements.txt`, and `pyproject.toml` alongside functional changes so Codex instructions stay authoritative.
+
+---
+
+## 8. Support & Licensing
+
+The package is published as `diaremot` with version `2.1.0` (see `pyproject.toml`). Licensing is proprietary; ensure distribution complies with your organisation's policies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "llvmlite==0.42.0",
     "resampy==0.4.2",
     "soundfile==0.12.1",
+    "praat-parselmouth==0.4.3",
     "torch==2.4.1+cpu",
     "torchaudio==2.4.1+cpu",
     "torchvision==0.19.1+cpu",
@@ -25,25 +26,22 @@ dependencies = [
     "faster-whisper==1.1.0",
     "openai-whisper==20231117",
     "transformers==4.38.2",
+    "huggingface_hub==0.24.6",
     "onnxruntime==1.17.1",
     "tokenizers==0.15.2",
-    "huggingface_hub==0.24.6",
     "pandas==2.0.3",
     "scikit-learn==1.3.2",
-    "audioread==3.0.1",
-    "pydub==0.25.1",
-    "ffmpeg-python==0.2.0",
     "matplotlib==3.7.5",
     "seaborn==0.13.2",
     "reportlab==4.1.0",
-    "praat-parselmouth==0.4.3",
-    "jinja2==3.1.6",
-    "beautifulsoup4==4.12.3",
+    "audioread==3.0.1",
+    "pydub==0.25.1",
+    "ffmpeg-python==0.2.0",
     "tqdm==4.66.4",
     "joblib==1.3.2",
     "psutil==5.9.8",
-    "click==8.1.7",
     "typer==0.9.0",
+    "click==8.1.7",
     "pydantic==2.8.2",
 ]
 
@@ -56,8 +54,3 @@ diaremot-diagnostics = "diaremot.cli:main_diagnostics"
 
 [tool.setuptools.packages.find]
 where = ["src"]
-
-
-
-
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,51 +1,44 @@
-# Core dependencies with fixed versions for stability
-# Global index configuration (PyTorch CPU wheels + PyPI)
+# CPU-only dependencies pinned for deterministic offline installs
 --index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://pypi.org/simple
+
+# Numerics & signal processing
 numpy==1.24.4
 scipy==1.10.1
-# Pin librosa/numba/llvmlite for Windows/Python 3.11 compatibility
 librosa==0.10.2.post1
 numba==0.59.1
 llvmlite==0.42.0
 resampy==0.4.2
 soundfile==0.12.1
 praat-parselmouth==0.4.3
-# Use CPU-only builds from the PyTorch index
+
+# PyTorch CPU stack
 torch==2.4.1+cpu
 torchaudio==2.4.1+cpu
 torchvision==0.19.1+cpu
 
-# Transcription
+# Speech & language models
 ctranslate2==4.6.0
 faster-whisper==1.1.0
 openai-whisper==20231117
-
-# ML/AI
 transformers==4.38.2
 huggingface_hub==0.24.6
 onnxruntime==1.17.1
 tokenizers==0.15.2
 
-# Data processing
+# Analytics & ML utilities
 pandas==2.0.3
 scikit-learn==1.3.2
-
-# Audio processing utilities
-audioread==3.0.1
-pydub==0.25.1
-ffmpeg-python==0.2.0
-
-# Visualization and reporting
 matplotlib==3.7.5
 seaborn==0.13.2
 reportlab==4.1.0
 
-# Web/HTML
-jinja2==3.1.6
-beautifulsoup4==4.12.3
+# Audio utilities & IO
+audioread==3.0.1
+pydub==0.25.1
+ffmpeg-python==0.2.0
 
-# Utilities
+# Runtime tooling
 tqdm==4.66.4
 joblib==1.3.2
 psutil==5.9.8


### PR DESCRIPTION
## Summary
- rewrite README with current pipeline description, quickstart guidance, and output documentation
- update AGENTS.md run instructions to point to the Typer CLI groups and strict diagnostics command
- align requirements.txt and pyproject.toml dependency lists, removing unused web packages and regrouping related pins

## Testing
- pytest -q *(fails: ModuleNotFoundError: No module named 'pydantic' in the bare environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9b0b4d68c832e9ed539b09604aa91