### PR TITLE
Allow disabling chunking via CLI and add affect backend auto option

### DIFF
--- a/src/diaremot/pipeline/cli_entry.py
+++ b/src/diaremot/pipeline/cli_entry.py
@@ -86,7 +86,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--affect-backend",
         default="onnx",
-        choices=["onnx", "torch"],
+        choices=["auto", "onnx", "torch"],
         help="Backend for affect analysis",
     )
     parser.add_argument(
@@ -119,7 +119,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--chunk-enabled",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
         default=True,
         help="Enable automatic chunking",
     )

--- a/tests/test_pipeline_cli_entry_module.py
+++ b/tests/test_pipeline_cli_entry_module.py
@@ -27,6 +27,19 @@ def test_args_to_config_includes_flags() -> None:
     assert config["ignore_tx_cache"] is True
 
 
+def test_args_to_config_handles_chunk_toggle() -> None:
+    parser = cli_entry._build_arg_parser()
+    args = parser.parse_args([
+        "--input",
+        "sample.wav",
+        "--outdir",
+        "out",
+        "--no-chunk-enabled",
+    ])
+    config = cli_entry._args_to_config(args, ignore_tx_cache=False)
+    assert config["auto_chunk_enabled"] is False
+
+
 def test_main_verify_deps(monkeypatch: pytest.MonkeyPatch, capsys: Any) -> None:
     called = {}
 


### PR DESCRIPTION
## Summary
- allow the pipeline CLI to disable automatic chunking using argparse.BooleanOptionalAction
- expose the affect backend "auto" option to match the PipelineConfig validator
- add coverage ensuring the CLI surfaces the chunk toggle correctly

## Testing
- pytest -q *(fails: missing optional dependency pydantic in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da0386d5e4832eaeec976994979a4b