### PR TITLE
Replace pydantic config dependency and improve checkpoint hashing

### DIFF
--- a/src/diaremot/pipeline/pipeline_checkpoint_system.py
+++ b/src/diaremot/pipeline/pipeline_checkpoint_system.py
@@ -121,7 +121,7 @@ class PipelineCheckpointManager:
             if not file_path.exists():
                 return ""
 
-            digest = hash_file(file_path)
+            digest = hash_file(file_path, open_func=open)
             normalized = self._normalize_hash_value(digest)
             self._hash_cache[key] = normalized
             return normalized


### PR DESCRIPTION
## Summary
- replace the pipeline configuration model with an internal dataclass that retains validation without requiring pydantic
- extend the hash helper to accept a custom opener and ensure the checkpoint manager reuses the cached hash without re-reading audio files

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68da047ff6c4832e831746bc2fc0b1bd