### PR TITLE
Handle invalid CLI configs gracefully

### DIFF
--- a/tests/test_pipeline_cli_entry_module.py
+++ b/tests/test_pipeline_cli_entry_module.py
@@ -27,6 +27,45 @@ def test_args_to_config_includes_flags() -> None:
     assert config["ignore_tx_cache"] is True
 
 
+def test_args_to_config_handles_chunk_toggle() -> None:
+    parser = cli_entry._build_arg_parser()
+    args = parser.parse_args([
+        "--input",
+        "sample.wav",
+        "--outdir",
+        "out",
+        "--no-chunk-enabled",
+    ])
+    config = cli_entry._args_to_config(args, ignore_tx_cache=False)
+    assert config["auto_chunk_enabled"] is False
+
+
+def test_args_to_config_defaults_preserve_chunking() -> None:
+    parser = cli_entry._build_arg_parser()
+    args = parser.parse_args([
+        "--input",
+        "sample.wav",
+        "--outdir",
+        "out",
+    ])
+    config = cli_entry._args_to_config(args, ignore_tx_cache=False)
+    assert config["auto_chunk_enabled"] is True
+
+
+def test_args_to_config_accepts_affect_backend_auto() -> None:
+    parser = cli_entry._build_arg_parser()
+    args = parser.parse_args([
+        "--input",
+        "sample.wav",
+        "--outdir",
+        "out",
+        "--affect-backend",
+        "auto",
+    ])
+    config = cli_entry._args_to_config(args, ignore_tx_cache=False)
+    assert config["affect_backend"] == "auto"
+
+
 def test_main_verify_deps(monkeypatch: pytest.MonkeyPatch, capsys: Any) -> None:
     called = {}
 
@@ -90,3 +129,29 @@ def test_main_runs_pipeline(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, cap
     assert recorded["input"] == str(audio)
     assert recorded["out"] == str(outdir)
     assert recorded["config"]["ignore_tx_cache"] is True
+
+
+def test_main_rejects_invalid_config(monkeypatch: pytest.MonkeyPatch, capsys: Any) -> None:
+    def fail(*_args: Any, **_kwargs: Any) -> None:
+        pytest.fail("Pipeline should not be instantiated when configuration is invalid")
+
+    monkeypatch.setattr(cli_entry, "AudioAnalysisPipelineV2", fail)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_entry.main(
+            [
+                "--input",
+                "sample.wav",
+                "--outdir",
+                "out",
+                "--chunk-threshold-minutes",
+                "10",
+                "--chunk-size-minutes",
+                "20",
+            ]
+        )
+
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "Invalid configuration" in captured.err
+    assert "chunk_threshold_minutes must be >= chunk_size_minutes" in captured.err


### PR DESCRIPTION
## Summary
- allow the pipeline CLI to disable automatic chunking using argparse.BooleanOptionalAction
- expose the affect backend "auto" option to match the PipelineConfig validator
- extend regression coverage to confirm the CLI preserves default chunking and accepts the affect backend "auto" flag
- surface CLI configuration validation errors as actionable parser failures and cover the failure mode with tests

## Testing
- pytest tests/test_pipeline_cli_entry_module.py -q *(fails: missing optional dependency pydantic in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da0386d5e4832eaeec976994979a4b