### PR TITLE
Fix pipeline logging utilities context manager

### DIFF
--- a/src/diaremot/pipeline/logging_utils.py
+++ b/src/diaremot/pipeline/logging_utils.py
@@ -1,4 +1,3 @@
-
 from __future__ import annotations
 
 import hashlib
@@ -6,6 +5,7 @@ import json
 import logging
 import subprocess
 import time
+from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -83,6 +83,41 @@ class CoreLogger:
         self.log.error(message)
 
 
+def _fmt_hms(seconds: float) -> str:
+    """Return a human readable H:MM:SS style string for ``seconds``."""
+
+    safe_seconds = max(0.0, float(seconds))
+    total_seconds = int(safe_seconds)
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, secs = divmod(remainder, 60)
+
+    if hours:
+        return f"{hours:d}:{minutes:02d}:{secs:02d}"
+    return f"{minutes:02d}:{secs:02d}"
+
+
+def _fmt_hms_ms(milliseconds: float) -> str:
+    """Return a human readable string with millisecond precision."""
+
+    safe_ms = max(0.0, float(milliseconds))
+    seconds = safe_ms / 1000.0
+    base_seconds = int(seconds)
+    fractional_ms = int(round((seconds - base_seconds) * 1000))
+
+    if fractional_ms == 1000:
+        base_seconds += 1
+        fractional_ms = 0
+
+    hours, remainder = divmod(base_seconds, 3600)
+    minutes, secs = divmod(remainder, 60)
+
+    if hours:
+        return f"{hours:d}:{minutes:02d}:{secs:02d}.{fractional_ms:03d}"
+    if minutes:
+        return f"{minutes:02d}:{secs:02d}.{fractional_ms:03d}"
+    return f"00:{secs:02d}.{fractional_ms:03d}"
+
+
 class StageGuard(AbstractContextManager["StageGuard"]):
 
     _OPTIONAL_STAGE_EXCEPTION_MAP = {
@@ -121,13 +156,15 @@ class StageGuard(AbstractContextManager["StageGuard"]):
 
 
     def __init__(self, corelog: CoreLogger, stats: RunStats, stage: str):
-
         self.corelog = corelog
         self.stats = stats
         self.stage = stage
         self.start: float | None = None
         self.corelog.info(f"[{self.stage}] start")
 
+    def __enter__(self) -> "StageGuard":
+        self.start = time.time()
+        self.corelog.event(self.stage, "start")
         return self
 
     def done(self, **counts: int) -> None:


### PR DESCRIPTION
## Summary
- add duration helper formatters used by the pipeline exports
- make `StageGuard` a proper context manager by importing `AbstractContextManager` and implementing `__enter__`

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68daf6767474832eb41b30103d1b89c8