### PR TITLE
Refine core package loaders and affect analysis docs

### DIFF
--- a/src/diaremot/__init__.py
+++ b/src/diaremot/__init__.py
@@ -1,25 +1,24 @@
+"""DiaRemot package entry point with lazy-loading helpers."""
 
-"""
-DiaRemot: Enhanced Speech ML Analysis Package
-Optimized lazy-loading with comprehensive integration
-"""
-
-__version__ = "2.1.0"
-__author__ = "DiaRemot ML Team"
+from __future__ import annotations
 
 import importlib
 import logging
 import os
 import sys
+import time
 import types
 from pathlib import Path
-from typing import Optional, Dict, Any, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from .io.download_utils import download_file
 
+__version__ = "2.1.0"
+__author__ = "DiaRemot ML Team"
+
+
 # Module caches for lazy loading
-_cached_modules = {}
-_logger = logging.getLogger(__name__)
+_cached_modules: Dict[str, Any] = {}
 
 _LEGACY_MODULE_ALIASES = {
     "audio_pipeline_core": "diaremot.pipeline.audio_pipeline_core",
@@ -76,8 +75,8 @@ for _legacy_name, _target in _LEGACY_MODULE_ALIASES.items():
     _install_legacy_alias(_legacy_name, _target)
 
 
-def _get_or_create_logger():
-    """Get package logger with appropriate configuration"""
+def _get_or_create_logger() -> logging.Logger:
+    """Return the package logger, configuring it on first use."""
     logger = logging.getLogger("diaremot")
     if not logger.handlers:
         handler = logging.StreamHandler()
@@ -90,7 +89,7 @@ def _get_or_create_logger():
 
 
 def get_preprocessor(config: Optional[Dict[str, Any]] = None):
-    """Get AudioPreprocessor with configuration"""
+    """Return an ``AudioPreprocessor`` instance configured for CPU use."""
     if "preprocessor" not in _cached_modules:
         try:
             from .pipeline.audio_preprocessing import (
@@ -115,7 +114,7 @@ def get_preprocessor(config: Optional[Dict[str, Any]] = None):
 
 
 def get_diarizer(config: Optional[Dict[str, Any]] = None):
-    """Get SpeakerDiarizer with configuration and registry integration"""
+    """Return a ``SpeakerDiarizer`` instance with optional overrides."""
     if "diarizer" not in _cached_modules:
         try:
             from .pipeline.speaker_diarization import (
@@ -140,7 +139,7 @@ def get_diarizer(config: Optional[Dict[str, Any]] = None):
 
 
 def get_transcriber(config: Optional[Dict[str, Any]] = None):
-    """Get AudioTranscriber with CPU optimization"""
+    """Return an ``AudioTranscriber`` configured for CPU-only inference."""
     if "transcriber" not in _cached_modules:
         try:
             from .pipeline.transcription_module import (
@@ -172,7 +171,7 @@ def get_transcriber(config: Optional[Dict[str, Any]] = None):
 
 
 def get_pipeline(config: Optional[Dict[str, Any]] = None):
-    """Get enhanced AudioAnalysisPipelineV2 with full integration"""
+    """Return the ``AudioAnalysisPipelineV2`` entry point."""
     if "pipeline" not in _cached_modules:
         try:
             from .pipeline.audio_pipeline_core import AudioAnalysisPipelineV2
@@ -188,7 +187,7 @@ def get_pipeline(config: Optional[Dict[str, Any]] = None):
 
 
 def get_registry_manager(registry_path: Optional[str] = None):
-    """Get thread-safe speaker registry manager"""
+    """Return the speaker registry manager used across the pipeline."""
     if "registry" not in _cached_modules:
         try:
             from .io.speaker_registry_manager import SpeakerRegistryManager
@@ -209,7 +208,7 @@ def get_registry_manager(registry_path: Optional[str] = None):
 
 
 def get_checkpoint_manager(checkpoint_dir: Optional[str] = None):
-    """Get pipeline checkpoint manager for resume functionality"""
+    """Return the pipeline checkpoint manager for resume support."""
     if "checkpoint" not in _cached_modules:
         try:
             from .pipeline.pipeline_checkpoint_system import (
@@ -236,7 +235,7 @@ def get_checkpoint_manager(checkpoint_dir: Optional[str] = None):
 def create_integrated_pipeline(
     config: Optional[Dict[str, Any]] = None,
 ) -> Tuple[Any, Dict[str, Any]]:
-    """Create fully integrated pipeline with all components"""
+    """Construct the pipeline alongside the ancillary managers."""
     config = config or {}
 
     # Initialize core components
@@ -259,9 +258,9 @@ def create_integrated_pipeline(
 
 # Package health check
 def validate_system() -> Dict[str, Any]:
-    """Comprehensive system validation"""
+    """Run a comprehensive system validation for the public API."""
     status = {
-        "timestamp": __import__("time").strftime("%Y-%m-%d %H:%M:%S"),
+        "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
         "version": __version__,
         "components": {},
         "critical_issues": [],

--- a/src/diaremot/affect/emotion_analyzer.py
+++ b/src/diaremot/affect/emotion_analyzer.py
@@ -26,7 +26,7 @@ import os
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Optional, Tuple
 
 # Optional heavy deps are imported lazily inside methods.
 # librosa is cheap enough; used for fallbacks and basic features.
@@ -125,14 +125,6 @@ GOEMOTIONS_AMBIGUOUS = {"confusion", "curiosity", "realization", "surprise"}
 # --------------------------
 
 
-def _softmax(x: np.ndarray) -> np.ndarray:
-    x = np.asarray(x, dtype=np.float64)
-    x = x - np.max(x)
-    e = np.exp(x)
-    s = e.sum() or 1.0
-    return (e / s).astype(np.float64)
-
-
 def _entropy(probs: Dict[str, float]) -> float:
     p = np.clip(np.array(list(probs.values()), dtype=np.float64), 1e-12, 1.0)
     return float(-np.sum(p * np.log(p)))
@@ -203,22 +195,6 @@ def _trim_max_len(audio: np.ndarray, sr: int, max_sec: float = 30.0) -> np.ndarr
     return audio[:nmax] if audio.size > nmax else audio
 
 
-def _text_tokens(text: str) -> List[str]:
-    if not text:
-        return []
-    out, buf = [], []
-    for ch in text:
-        if ch.isalnum() or ch in ["'", "-"]:
-            buf.append(ch.lower())
-        else:
-            if buf:
-                out.append("".join(buf))
-                buf = []
-    if buf:
-        out.append("".join(buf))
-    return out
-
-
 # --------------------------
 # Dataclass (internal use)
 # --------------------------
@@ -285,7 +261,6 @@ class EmotionIntentAnalyzer:
         # Lazy handles
         self._vad_processor = None
         self._vad_model = None
-        a = None  # noqa
         self._vad_idx = None  # {'valence': i, 'arousal': j, 'dominance': k}
 
         self._ser_processor = None
@@ -566,9 +541,7 @@ class EmotionIntentAnalyzer:
                 model_path = ensure_onnx_model(ident)
                 self._ser_session = create_onnx_session(model_path)
             except Exception as e:
-                logger.warning(
-                    f"SER ONNX model unavailable ({e}); will use fallback"
-                )
+                logger.warning(f"SER ONNX model unavailable ({e}); will use fallback")
                 self._ser_processor = None
                 self._ser_session = None
         else:
@@ -590,9 +563,7 @@ class EmotionIntentAnalyzer:
                     self.ser_model_name
                 )
             except Exception as e:
-                logger.warning(
-                    f"SER model unavailable ({e}); will use fallback"
-                )
+                logger.warning(f"SER model unavailable ({e}); will use fallback")
                 self._ser_processor = None
                 self._ser_model = None
 
@@ -721,9 +692,7 @@ class EmotionIntentAnalyzer:
                 model_path = ensure_onnx_model(ident)
                 self._text_session = create_onnx_session(model_path)
             except Exception as e:
-                logger.warning(
-                    f"Text ONNX model unavailable ({e}); will use fallback"
-                )
+                logger.warning(f"Text ONNX model unavailable ({e}); will use fallback")
                 self._text_session = None
                 self._text_tokenizer = None
         else:
@@ -753,9 +722,7 @@ class EmotionIntentAnalyzer:
                     or not text.strip()
                 ):
                     raise RuntimeError("text model missing or text empty")
-                enc = self._text_tokenizer(
-                    text, return_tensors="np", truncation=True
-                )
+                enc = self._text_tokenizer(text, return_tensors="np", truncation=True)
                 ort_inputs = {k: v for k, v in enc.items()}
                 logits = self._text_session.run(None, ort_inputs)[0]
                 if logits.ndim == 2:
@@ -864,7 +831,9 @@ class EmotionIntentAnalyzer:
             )
         except Exception as e:
             if self.affect_backend == "onnx":
-                logger.info("Intent ONNX backend not implemented; using transformer pipeline fallback")
+                logger.info(
+                    "Intent ONNX backend not implemented; using transformer pipeline fallback"
+                )
             logger.warning(f"Intent model unavailable ({e}); will use fallback")
             self._intent_pipeline = None
 
@@ -968,10 +937,12 @@ class EmotionIntentAnalyzer:
             + ser_probs.get("disgusted", 0.0)
         )
         ser_neu = ser_probs.get("neutral", 0.0) + ser_probs.get("calm", 0.0)
-        ser_label = max(
-            {"positive": ser_pos, "negative": ser_neg, "neutral": ser_neu},
-            key=lambda k: {"positive": ser_pos, "negative": ser_neg, "neutral": ser_neu}[k],
-        )
+        ser_polarity = {
+            "positive": ser_pos,
+            "negative": ser_neg,
+            "neutral": ser_neu,
+        }
+        ser_label = max(ser_polarity, key=ser_polarity.get)
 
         # Text polarity
         text_label = max(pol, key=pol.get) if pol else "neutral"
@@ -984,15 +955,23 @@ class EmotionIntentAnalyzer:
         if ser_label == "neutral" and text_label != "neutral":
             return f"text-dominant-{text_label}"
 
-        v_sign_text = 1 if text_label == "positive" else (-1 if text_label == "negative" else 0)
+        v_sign_text = (
+            1 if text_label == "positive" else (-1 if text_label == "negative" else 0)
+        )
         v_sign_audio = 1 if v > 0.15 else (-1 if v < -0.15 else 0)
         aligned = (v_sign_text == v_sign_audio) or (v_sign_text == 0 and abs(v) < 0.15)
-        polarity_tag = text_label if text_label in ("positive", "negative") else ser_label
-        return (
+        polarity_tag = (
+            text_label if text_label in ("positive", "negative") else ser_label
+        )
+        hint = (
             f"affect-convergent-{polarity_tag}"
             if aligned
             else f"affect-divergent-{polarity_tag}"
         )
+        arousal_level = "high" if a > 0.4 else "low" if a < -0.4 else None
+        if arousal_level:
+            hint = f"{hint} | arousal-{arousal_level}"
+        return hint
 
 
 # End class

--- a/src/diaremot/affect/paralinguistics.py
+++ b/src/diaremot/affect/paralinguistics.py
@@ -1,19 +1,17 @@
-# paralinguistics.py
-# Production-optimized paralinguistic feature extraction with enhanced CPU performance
-# Version 2.1.0 - Full pipeline integration with advanced voice quality analysis
-
-"""Paralinguistic feature extraction utilities.
+"""Production-optimized paralinguistic feature extraction utilities.
 
 Provides advanced speech metrics such as words per minute (WPM) and syllables
-per second (SPS). Both metrics are stored with two-decimal precision.
+per second (SPS). Both metrics are stored with two-decimal precision. The
+module targets CPU-only deployments and includes enhanced voice-quality
+analysis.
 """
 
 from __future__ import annotations
 
 import json
-import warnings
-import time
 import os
+import time
+import warnings
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from functools import lru_cache

--- a/src/diaremot/affect/sed_panns.py
+++ b/src/diaremot/affect/sed_panns.py
@@ -1,18 +1,18 @@
-"""This module is optional. If panns_inference/librosa are unavailable, it
-degrades gracefully and returns no tags."""
+"""Optional background sound tagging via PANNs models."""
 
 from __future__ import annotations
 
 import csv
+from contextlib import contextmanager
 from dataclasses import dataclass
 import logging
-from pathlib import Path
 import os
-from typing import Any, Dict, Optional, Tuple, List
-from contextlib import contextmanager
+from pathlib import Path
 import sys
+from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
+
 from ..io.onnx_utils import create_onnx_session
 
 if os.name == "nt":
@@ -32,29 +32,34 @@ else:
 logger = logging.getLogger(__name__)
 
 try:  # pragma: no cover - optional dependency
-    import librosa  # type: ignore
+    import librosa  # type: ignore[import-not-found]
 
     _HAVE_LIBROSA = True
 except Exception:  # pragma: no cover - env dependent
     _HAVE_LIBROSA = False
 
-try:
-    import onnxruntime as ort  # type: ignore
+try:  # pragma: no cover - optional dependency
+    import onnxruntime as ort  # type: ignore[import-not-found]
 
     _HAVE_ORT = True
 except Exception:  # pragma: no cover - env dependent
     _HAVE_ORT = False
-    ort = None  # type: ignore
+    ort = None  # type: ignore[assignment]
 
 try:
     # Cheap check without importing (avoids triggering wget in panns_inference)
-    import importlib.util as _ilu  # type: ignore
+    import importlib.util as _ilu  # type: ignore[import-not-found]
 
     _HAVE_PANNS = _ilu.find_spec("panns_inference") is not None
 except Exception:
     _HAVE_PANNS = False
-AudioTagging = None  # type: ignore
-labels = []  # type: ignore
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from panns_inference import AudioTagging as _PannsAudioTagging
+else:  # pragma: no cover - runtime fallback
+    _PannsAudioTagging = Any
+
+labels: list[str] = []
 
 
 _NOISE_KEYWORDS = (
@@ -111,9 +116,9 @@ class PANNSEventTagger:
             else:
                 backend = "none"
         self.backend = backend
-        self._tagger: Optional[AudioTagging] = None  # type: ignore
+        self._tagger: Optional[_PannsAudioTagging] = None
         self._session: Optional["ort.InferenceSession"] = None
-        self._labels: Optional[List[str]] = None
+        self._labels: Optional[list[str]] = None
         self.available = True
         self._ensure_model()
         if not self.available:
@@ -140,7 +145,7 @@ class PANNSEventTagger:
                             with lp.open() as f:
                                 reader = csv.DictReader(f)
                                 self._labels = [
-                                    row.get("display_name", "") for row in reader
+                                    str(row.get("display_name", "")) for row in reader
                                 ]
                             return
                         except Exception as exc:
@@ -156,7 +161,7 @@ class PANNSEventTagger:
                         os.getenv("HF_HOME"),
                         os.getenv("HUGGINGFACE_HUB_CACHE"),
                     ]
-                    for root in [Path(p) for p in env_roots if p]:
+                    for root in (Path(p) for p in env_roots if p):
                         try:
                             if not root.exists():
                                 continue
@@ -180,10 +185,14 @@ class PANNSEventTagger:
                                 self._session = create_onnx_session(mp)
                                 with lp.open() as f:
                                     reader = csv.DictReader(f)
-                                    self._labels = [row.get("display_name", "") for row in reader]
+                                    self._labels = [
+                                        row.get("display_name", "") for row in reader
+                                    ]
                                 return
                         except Exception as exc:
-                            logger.info("Failed loading ONNX from env root %s: %s", root, exc)
+                            logger.info(
+                                "Failed loading ONNX from env root %s: %s", root, exc
+                            )
                 if self._session is None or not self._labels:
                     logger.info(
                         "PANNs ONNX assets not found locally; skipping remote download fallback"
@@ -217,8 +226,13 @@ class PANNSEventTagger:
                     cand = self.cfg.model_dir / "class_labels_indices.csv"
                     if cand.exists():
                         src_labels = cand
-                if src_labels and not (home_panns / "class_labels_indices.csv").exists():
-                    (home_panns / "class_labels_indices.csv").write_bytes(src_labels.read_bytes())
+                if (
+                    src_labels
+                    and not (home_panns / "class_labels_indices.csv").exists()
+                ):
+                    (home_panns / "class_labels_indices.csv").write_bytes(
+                        src_labels.read_bytes()
+                    )
             except Exception:
                 pass
 
@@ -274,7 +288,7 @@ class PANNSEventTagger:
         else:
             self.available = False
 
-    def _resample_to_32k(self, audio: np.ndarray, sr: int) -> Tuple[np.ndarray, int]:
+    def _resample_to_32k(self, audio: np.ndarray, sr: int) -> tuple[np.ndarray, int]:
         if sr == 32000:
             return audio.astype(np.float32, copy=False), sr
         if _HAVE_LIBROSA:
@@ -286,8 +300,7 @@ class PANNSEventTagger:
             except Exception:
                 pass
         if sr == 16000:
-            y = np.repeat(audio.astype(np.float32), 2)
-            return y, 32000
+            return np.repeat(audio.astype(np.float32), 2), 32000
         ratio = 32000 / float(sr)
         new_len = int(round(len(audio) * ratio))
         if new_len <= 1:
@@ -297,7 +310,7 @@ class PANNSEventTagger:
         y = np.interp(x_new, x_old, audio).astype(np.float32)
         return y, 32000
 
-    def tag(self, audio_16k_mono: np.ndarray, sr: int) -> Optional[Dict[str, Any]]:
+    def tag(self, audio_16k_mono: np.ndarray, sr: int) -> Optional[dict[str, Any]]:
         if not self.available:
             return None
         if audio_16k_mono is None or audio_16k_mono.size == 0:
@@ -313,10 +326,7 @@ class PANNSEventTagger:
         total_sec = len(y_in) / float(sr)
         if self.cfg.max_eval_sec and total_sec > self.cfg.max_eval_sec:
             max_samples = int(self.cfg.max_eval_sec * sr)
-            if (
-                self.cfg.eval_strategy == "uniform"
-                and (self.cfg.max_eval_sec or 0) > 0
-            ):
+            if self.cfg.eval_strategy == "uniform" and (self.cfg.max_eval_sec or 0) > 0:
                 # Take N uniform slices totaling max_eval_sec
                 slices = 5
                 seg_len = max_samples // slices
@@ -353,7 +363,7 @@ class PANNSEventTagger:
             except Exception:
                 return None
             # Prefer labels from the tagger; fallback to imported default
-            map_labels = getattr(self._tagger, "labels", labels) or []  # type: ignore
+            map_labels = list(getattr(self._tagger, "labels", labels)) or []  # type: ignore[arg-type]
 
         if clip.size == 0:
             return None

--- a/src/diaremot/cli.py
+++ b/src/diaremot/cli.py
@@ -18,7 +18,9 @@ app = typer.Typer(
     help="""High level CLI wrapper for the DiaRemot audio pipeline.\n\nThe CLI is now organised into domain-centric groups. For example:\n\n  • diaremot asr run --input sample.wav --outdir outputs/run1\n  • diaremot vad debug --input sample.wav\n  • diaremot report gen --manifest outputs/run1/manifest.json""",
     rich_markup_mode="markdown",
 )
-asr_app = typer.Typer(help="Automatic speech recognition, diarization and affect pipeline commands.")
+asr_app = typer.Typer(
+    help="Automatic speech recognition, diarization and affect pipeline commands."
+)
 vad_app = typer.Typer(help="Voice activity detection tooling.")
 report_app = typer.Typer(help="Reporting and summary generation utilities.")
 system_app = typer.Typer(help="System level diagnostics and maintenance commands.")
@@ -120,7 +122,9 @@ def _normalise_path(value: Optional[Path]) -> Optional[str]:
     return str(value.expanduser().resolve())
 
 
-def _merge_configs(profile_overrides: Dict[str, Any], cli_overrides: Dict[str, Any]) -> Dict[str, Any]:
+def _merge_configs(
+    profile_overrides: Dict[str, Any], cli_overrides: Dict[str, Any]
+) -> Dict[str, Any]:
     merged: Dict[str, Any] = dict(profile_overrides)
     defaults = _default_config().model_dump(mode="python")
     for key, value in cli_overrides.items():
@@ -132,7 +136,9 @@ def _merge_configs(profile_overrides: Dict[str, Any], cli_overrides: Dict[str, A
     return merged
 
 
-def _validate_assets(input_path: Path, output_dir: Path, config: PipelineConfig) -> None:
+def _validate_assets(
+    input_path: Path, output_dir: Path, config: PipelineConfig
+) -> None:
     errors: List[str] = []
 
     if not input_path.exists():
@@ -231,20 +237,30 @@ def _common_options(**kwargs: Any) -> Dict[str, Any]:
 @asr_app.command("run")
 def asr_run(
     input: Path = typer.Option(..., "--input", "-i", help="Path to input audio file."),
-    outdir: Path = typer.Option(..., "--outdir", "-o", help="Directory to write outputs."),
+    outdir: Path = typer.Option(
+        ..., "--outdir", "-o", help="Directory to write outputs."
+    ),
     profile: Optional[str] = typer.Option(
         None,
         "--profile",
         help=f"Configuration profile to load ({', '.join(BUILTIN_PROFILES)} or path to JSON).",
     ),
-    registry_path: Path = typer.Option(Path("speaker_registry.json"), help="Speaker registry path."),
-    ahc_distance_threshold: float = typer.Option(0.12, help="Agglomerative clustering distance threshold."),
-    speaker_limit: Optional[int] = typer.Option(None, help="Maximum number of speakers to keep."),
+    registry_path: Path = typer.Option(
+        Path("speaker_registry.json"), help="Speaker registry path."
+    ),
+    ahc_distance_threshold: float = typer.Option(
+        0.12, help="Agglomerative clustering distance threshold."
+    ),
+    speaker_limit: Optional[int] = typer.Option(
+        None, help="Maximum number of speakers to keep."
+    ),
     whisper_model: str = typer.Option(
         "faster-whisper-tiny.en", help="Whisper/Faster-Whisper model identifier."
     ),
     asr_backend: str = typer.Option("faster", help="ASR backend", show_default=True),
-    asr_compute_type: str = typer.Option("float32", help="CT2 compute type for faster-whisper."),
+    asr_compute_type: str = typer.Option(
+        "float32", help="CT2 compute type for faster-whisper."
+    ),
     asr_cpu_threads: int = typer.Option(1, help="CPU threads for ASR backend."),
     language: Optional[str] = typer.Option(None, help="Override ASR language"),
     language_mode: str = typer.Option("auto", help="Language detection mode"),
@@ -266,12 +282,20 @@ def asr_run(
         help="Skip affect analysis.",
         is_flag=True,
     ),
-    affect_backend: str = typer.Option("onnx", help="Affect backend (auto/torch/onnx)."),
-    affect_text_model_dir: Optional[Path] = typer.Option(None, help="Path to GoEmotions model directory."),
-    affect_intent_model_dir: Optional[Path] = typer.Option(None, help="Path to intent model directory."),
+    affect_backend: str = typer.Option(
+        "onnx", help="Affect backend (auto/torch/onnx)."
+    ),
+    affect_text_model_dir: Optional[Path] = typer.Option(
+        None, help="Path to GoEmotions model directory."
+    ),
+    affect_intent_model_dir: Optional[Path] = typer.Option(
+        None, help="Path to intent model directory."
+    ),
     beam_size: int = typer.Option(1, help="Beam size for ASR decoding."),
     temperature: float = typer.Option(0.0, help="Sampling temperature for ASR."),
-    no_speech_threshold: float = typer.Option(0.50, help="No-speech threshold for Whisper."),
+    no_speech_threshold: float = typer.Option(
+        0.50, help="No-speech threshold for Whisper."
+    ),
     noise_reduction: bool = typer.Option(
         False,
         "--noise-reduction",
@@ -289,14 +313,26 @@ def asr_run(
         "--chunk-enabled",
         help="Set automatic chunking of long files (true/false).",
     ),
-    chunk_threshold_minutes: float = typer.Option(30.0, help="Chunking activation threshold."),
+    chunk_threshold_minutes: float = typer.Option(
+        30.0, help="Chunking activation threshold."
+    ),
     chunk_size_minutes: float = typer.Option(20.0, help="Chunk size in minutes."),
-    chunk_overlap_seconds: float = typer.Option(30.0, help="Overlap between chunks in seconds."),
+    chunk_overlap_seconds: float = typer.Option(
+        30.0, help="Overlap between chunks in seconds."
+    ),
     vad_threshold: float = typer.Option(0.30, help="Silero VAD probability threshold."),
-    vad_min_speech_sec: float = typer.Option(0.8, help="Minimum detected speech duration."),
-    vad_min_silence_sec: float = typer.Option(0.8, help="Minimum detected silence duration."),
-    vad_speech_pad_sec: float = typer.Option(0.2, help="Padding added around VAD speech regions."),
-    vad_backend: str = typer.Option("auto", help="Silero VAD backend (auto/torch/onnx)."),
+    vad_min_speech_sec: float = typer.Option(
+        0.8, help="Minimum detected speech duration."
+    ),
+    vad_min_silence_sec: float = typer.Option(
+        0.8, help="Minimum detected silence duration."
+    ),
+    vad_speech_pad_sec: float = typer.Option(
+        0.2, help="Padding added around VAD speech regions."
+    ),
+    vad_backend: str = typer.Option(
+        "auto", help="Silero VAD backend (auto/torch/onnx)."
+    ),
     disable_energy_vad_fallback: bool = typer.Option(
         False,
         "--disable-energy-fallback",
@@ -305,9 +341,13 @@ def asr_run(
     ),
     energy_gate_db: float = typer.Option(-33.0, help="Energy VAD gating threshold."),
     energy_hop_sec: float = typer.Option(0.01, help="Energy VAD hop length."),
-    asr_window_sec: int = typer.Option(480, help="Maximum audio length per ASR window."),
+    asr_window_sec: int = typer.Option(
+        480, help="Maximum audio length per ASR window."
+    ),
     asr_segment_timeout: float = typer.Option(300.0, help="Timeout per ASR segment."),
-    asr_batch_timeout: float = typer.Option(1200.0, help="Timeout for a batch of ASR segments."),
+    asr_batch_timeout: float = typer.Option(
+        1200.0, help="Timeout for a batch of ASR segments."
+    ),
     cpu_diarizer: bool = typer.Option(
         False,
         "--cpu-diarizer",
@@ -390,20 +430,30 @@ app.command("run")(asr_run)
 @asr_app.command("resume")
 def asr_resume(
     input: Path = typer.Option(..., "--input", "-i", help="Original input audio file."),
-    outdir: Path = typer.Option(..., "--outdir", "-o", help="Output directory used in the previous run."),
+    outdir: Path = typer.Option(
+        ..., "--outdir", "-o", help="Output directory used in the previous run."
+    ),
     profile: Optional[str] = typer.Option(
         None,
         "--profile",
         help=f"Configuration profile to load ({', '.join(BUILTIN_PROFILES)} or path to JSON).",
     ),
-    registry_path: Path = typer.Option(Path("speaker_registry.json"), help="Speaker registry path."),
-    ahc_distance_threshold: float = typer.Option(0.12, help="Agglomerative clustering distance threshold."),
-    speaker_limit: Optional[int] = typer.Option(None, help="Maximum number of speakers to keep."),
+    registry_path: Path = typer.Option(
+        Path("speaker_registry.json"), help="Speaker registry path."
+    ),
+    ahc_distance_threshold: float = typer.Option(
+        0.12, help="Agglomerative clustering distance threshold."
+    ),
+    speaker_limit: Optional[int] = typer.Option(
+        None, help="Maximum number of speakers to keep."
+    ),
     whisper_model: str = typer.Option(
         "faster-whisper-tiny.en", help="Whisper/Faster-Whisper model identifier."
     ),
     asr_backend: str = typer.Option("faster", help="ASR backend", show_default=True),
-    asr_compute_type: str = typer.Option("float32", help="CT2 compute type for faster-whisper."),
+    asr_compute_type: str = typer.Option(
+        "float32", help="CT2 compute type for faster-whisper."
+    ),
     asr_cpu_threads: int = typer.Option(1, help="CPU threads for ASR backend."),
     language: Optional[str] = typer.Option(None, help="Override ASR language"),
     language_mode: str = typer.Option("auto", help="Language detection mode"),
@@ -419,12 +469,20 @@ def asr_resume(
         help="Skip affect analysis.",
         is_flag=True,
     ),
-    affect_backend: str = typer.Option("onnx", help="Affect backend (auto/torch/onnx)."),
-    affect_text_model_dir: Optional[Path] = typer.Option(None, help="Path to GoEmotions model directory."),
-    affect_intent_model_dir: Optional[Path] = typer.Option(None, help="Path to intent model directory."),
+    affect_backend: str = typer.Option(
+        "onnx", help="Affect backend (auto/torch/onnx)."
+    ),
+    affect_text_model_dir: Optional[Path] = typer.Option(
+        None, help="Path to GoEmotions model directory."
+    ),
+    affect_intent_model_dir: Optional[Path] = typer.Option(
+        None, help="Path to intent model directory."
+    ),
     beam_size: int = typer.Option(1, help="Beam size for ASR decoding."),
     temperature: float = typer.Option(0.0, help="Sampling temperature for ASR."),
-    no_speech_threshold: float = typer.Option(0.50, help="No-speech threshold for Whisper."),
+    no_speech_threshold: float = typer.Option(
+        0.50, help="No-speech threshold for Whisper."
+    ),
     noise_reduction: bool = typer.Option(
         False,
         "--noise-reduction",
@@ -442,14 +500,26 @@ def asr_resume(
         "--chunk-enabled",
         help="Set automatic chunking of long files (true/false).",
     ),
-    chunk_threshold_minutes: float = typer.Option(30.0, help="Chunking activation threshold."),
+    chunk_threshold_minutes: float = typer.Option(
+        30.0, help="Chunking activation threshold."
+    ),
     chunk_size_minutes: float = typer.Option(20.0, help="Chunk size in minutes."),
-    chunk_overlap_seconds: float = typer.Option(30.0, help="Overlap between chunks in seconds."),
+    chunk_overlap_seconds: float = typer.Option(
+        30.0, help="Overlap between chunks in seconds."
+    ),
     vad_threshold: float = typer.Option(0.30, help="Silero VAD probability threshold."),
-    vad_min_speech_sec: float = typer.Option(0.8, help="Minimum detected speech duration."),
-    vad_min_silence_sec: float = typer.Option(0.8, help="Minimum detected silence duration."),
-    vad_speech_pad_sec: float = typer.Option(0.2, help="Padding added around VAD speech regions."),
-    vad_backend: str = typer.Option("auto", help="Silero VAD backend (auto/torch/onnx)."),
+    vad_min_speech_sec: float = typer.Option(
+        0.8, help="Minimum detected speech duration."
+    ),
+    vad_min_silence_sec: float = typer.Option(
+        0.8, help="Minimum detected silence duration."
+    ),
+    vad_speech_pad_sec: float = typer.Option(
+        0.2, help="Padding added around VAD speech regions."
+    ),
+    vad_backend: str = typer.Option(
+        "auto", help="Silero VAD backend (auto/torch/onnx)."
+    ),
     disable_energy_vad_fallback: bool = typer.Option(
         False,
         "--disable-energy-fallback",
@@ -458,9 +528,13 @@ def asr_resume(
     ),
     energy_gate_db: float = typer.Option(-33.0, help="Energy VAD gating threshold."),
     energy_hop_sec: float = typer.Option(0.01, help="Energy VAD hop length."),
-    asr_window_sec: int = typer.Option(480, help="Maximum audio length per ASR window."),
+    asr_window_sec: int = typer.Option(
+        480, help="Maximum audio length per ASR window."
+    ),
     asr_segment_timeout: float = typer.Option(300.0, help="Timeout per ASR segment."),
-    asr_batch_timeout: float = typer.Option(1200.0, help="Timeout for a batch of ASR segments."),
+    asr_batch_timeout: float = typer.Option(
+        1200.0, help="Timeout for a batch of ASR segments."
+    ),
     cpu_diarizer: bool = typer.Option(
         False,
         "--cpu-diarizer",
@@ -534,7 +608,9 @@ app.command("resume")(asr_resume)
 
 
 @system_app.command("diagnostics")
-def diagnostics(strict: bool = typer.Option(False, help="Require minimum dependency versions.")) -> None:
+def diagnostics(
+    strict: bool = typer.Option(False, help="Require minimum dependency versions."),
+) -> None:
     """Run dependency diagnostics and emit a JSON summary."""
 
     result = core_diagnostics(require_versions=strict)
@@ -584,15 +660,25 @@ def _load_speakers_csv(path: Path) -> List[Dict[str, Any]]:
 
 @report_app.command("gen")
 def report_gen(
-    manifest: Path = typer.Option(..., "--manifest", "-m", help="Manifest JSON from a pipeline run."),
-    outdir: Optional[Path] = typer.Option(None, "--outdir", help="Override output directory."),
-    format: List[str] = typer.Option(["pdf"], "--format", "-f", help="Formats to (re)generate: pdf or html."),
-    force: bool = typer.Option(False, "--force", help="Regenerate even if the target file already exists."),
+    manifest: Path = typer.Option(
+        ..., "--manifest", "-m", help="Manifest JSON from a pipeline run."
+    ),
+    outdir: Optional[Path] = typer.Option(
+        None, "--outdir", help="Override output directory."
+    ),
+    format: List[str] = typer.Option(
+        ["pdf"], "--format", "-f", help="Formats to (re)generate: pdf or html."
+    ),
+    force: bool = typer.Option(
+        False, "--force", help="Regenerate even if the target file already exists."
+    ),
 ) -> None:
     try:
         manifest_data = json.loads(manifest.read_text())
     except json.JSONDecodeError as exc:
-        raise typer.BadParameter(f"Manifest '{manifest}' is not valid JSON: {exc}") from exc
+        raise typer.BadParameter(
+            f"Manifest '{manifest}' is not valid JSON: {exc}"
+        ) from exc
 
     outputs = manifest_data.get("outputs", {}) or {}
     base_outdir = outdir or Path(manifest_data.get("out_dir", manifest.parent))
@@ -631,7 +717,9 @@ def report_gen(
     formats = {fmt.lower() for fmt in format}
     unknown_formats = formats - _REPORT_FORMATS
     if unknown_formats:
-        raise typer.BadParameter(f"Unsupported report format(s): {', '.join(sorted(unknown_formats))}")
+        raise typer.BadParameter(
+            f"Unsupported report format(s): {', '.join(sorted(unknown_formats))}"
+        )
 
     results: Dict[str, str] = {}
     file_id = manifest_data.get("file_id") or base_outdir.name
@@ -674,12 +762,24 @@ def report_gen(
 @vad_app.command("debug")
 def vad_debug(
     input: Path = typer.Option(..., "--input", "-i", help="Audio file to analyse."),
-    threshold: float = typer.Option(0.30, "--threshold", help="Silero probability threshold."),
-    min_speech: float = typer.Option(0.8, "--min-speech", help="Minimum detected speech duration."),
-    min_silence: float = typer.Option(0.8, "--min-silence", help="Minimum detected silence duration."),
-    pad: float = typer.Option(0.2, "--pad", help="Padding added around VAD speech regions."),
-    backend: str = typer.Option("auto", "--backend", help="Backend to use: auto/torch/onnx."),
-    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
+    threshold: float = typer.Option(
+        0.30, "--threshold", help="Silero probability threshold."
+    ),
+    min_speech: float = typer.Option(
+        0.8, "--min-speech", help="Minimum detected speech duration."
+    ),
+    min_silence: float = typer.Option(
+        0.8, "--min-silence", help="Minimum detected silence duration."
+    ),
+    pad: float = typer.Option(
+        0.2, "--pad", help="Padding added around VAD speech regions."
+    ),
+    backend: str = typer.Option(
+        "auto", "--backend", help="Backend to use: auto/torch/onnx."
+    ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit machine-readable JSON."
+    ),
 ) -> None:
     if not input.exists():
         raise typer.BadParameter(f"Input file '{input}' does not exist.")
@@ -700,8 +800,12 @@ def vad_debug(
 
     wav, sr = librosa.load(str(input), sr=cfg.target_sr, mono=True)
     wav = np.asarray(wav, dtype=np.float32)
-    detector = _SileroWrapper(cfg.vad_threshold, cfg.speech_pad_sec, backend=cfg.vad_backend)
-    speech_regions = detector.detect(wav, sr, cfg.vad_min_speech_sec, cfg.vad_min_silence_sec)
+    detector = _SileroWrapper(
+        cfg.vad_threshold, cfg.speech_pad_sec, backend=cfg.vad_backend
+    )
+    speech_regions = detector.detect(
+        wav, sr, cfg.vad_min_speech_sec, cfg.vad_min_silence_sec
+    )
 
     segments = [
         {

--- a/src/diaremot/io/onnx_utils.py
+++ b/src/diaremot/io/onnx_utils.py
@@ -1,4 +1,4 @@
-"""Helpers for retrieving and loading ONNX models consistently."""
+"""Utilities for ensuring and loading ONNX Runtime models."""
 
 from __future__ import annotations
 

--- a/src/diaremot/io/speaker_registry_manager.py
+++ b/src/diaremot/io/speaker_registry_manager.py
@@ -1,8 +1,9 @@
-"""Thread-safe wrapper around the SpeakerRegistry implementation.
+"""Thread-safe convenience wrapper around the diarization speaker registry.
 
 This module provides a lightweight manager facade that keeps access to the
-underlying :class:`diaremot.pipeline.speaker_diarization.SpeakerRegistry` serialized across
-threads and offers a small set of convenience helpers (auto-flush, reload).
+underlying :class:`diaremot.pipeline.speaker_diarization.SpeakerRegistry`
+serialised across threads and offers a small set of convenience helpers
+(auto-flush, reload).
 
 The public factory :func:`diaremot.get_registry_manager` wires to this
 manager so callers consistently receive a functional registry even though the
@@ -13,7 +14,7 @@ from __future__ import annotations
 
 import threading
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any
 
 
 class SpeakerRegistryManager:
@@ -58,19 +59,21 @@ class SpeakerRegistryManager:
             if self.auto_flush:
                 self._registry.save()
 
-    def match(self, centroid: Any) -> Tuple[Optional[str], float]:
+    def match(self, centroid: Any) -> tuple[str | None, float]:
         with self._lock:
             return self._registry.match(centroid)
 
-    def get_speakers(self) -> Dict[str, Dict[str, Any]]:
+    def get_speakers(self) -> dict[str, dict[str, Any]]:
         """Return a shallow copy of the stored speakers."""
 
         with self._lock:
             # ``SpeakerRegistry`` keeps the payload in ``_speakers``; copy it to
             # avoid leaking a mutable reference.
-            return {k: dict(v) for k, v in getattr(self._registry, "_speakers", {}).items()}
+            return {
+                k: dict(v) for k, v in getattr(self._registry, "_speakers", {}).items()
+            }
 
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> dict[str, Any]:
         with self._lock:
             return dict(getattr(self._registry, "_metadata", {}))
 


### PR DESCRIPTION
## Summary
- streamline the DiaRemot package entry point with typed caches, clearer docstrings, and standard time handling
- simplify affect analyzer utilities by removing dead helpers and enriching affect hints with arousal context
- refresh paralinguistics module documentation and standardize imports for readability

## Testing
- `ruff format src/diaremot/__init__.py src/diaremot/affect/__init__.py src/diaremot/affect/emotion_analyzer.py src/diaremot/affect/intent_defaults.py src/diaremot/affect/paralinguistics.py`
- `ruff check src/diaremot/__init__.py src/diaremot/affect/__init__.py src/diaremot/affect/emotion_analyzer.py src/diaremot/affect/intent_defaults.py src/diaremot/affect/paralinguistics.py`


------
https://chatgpt.com/codex/tasks/task_e_68dc168d692c832ea4d0d4e6537aad4d