### PR TITLE
Run Ruff formatting and harden optional dependency stubs

### DIFF
--- a/check_att.py
+++ b/check_att.py
@@ -1,2 +1,3 @@
 import panns_inference.models as pim
+
 print(hasattr(pim, "AttBlock"))

--- a/check_models.py
+++ b/check_models.py
@@ -1,2 +1,3 @@
 from panns_inference import models
+
 print([name for name in dir(models) if name.startswith("Cnn14")])

--- a/check_path.py
+++ b/check_path.py
@@ -1,3 +1,5 @@
-import inspect, os
+import inspect
+import os
 import panns_inference
+
 print(os.path.dirname(inspect.getfile(panns_inference)))

--- a/export_panns_onnx.py
+++ b/export_panns_onnx.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 """Export a PANNs checkpoint (CNN14 variants) to ONNX for offline SED inference."""
+
 from __future__ import annotations
 
 import argparse
 import sys
 from pathlib import Path
-from typing import Iterable, List, Sequence, Tuple
+from typing import List, Sequence, Tuple
 
 import torch
 
@@ -184,7 +185,9 @@ def export_model(args: argparse.Namespace) -> None:
         try:
             from onnxruntime.quantization import QuantType, quantize_dynamic
         except Exception as exc:  # pragma: no cover - optional
-            print(f"[warn] onnxruntime.quantization unavailable ({exc}); skipping INT8 export")
+            print(
+                f"[warn] onnxruntime.quantization unavailable ({exc}); skipping INT8 export"
+            )
             return
 
         int8_path = out_path.with_suffix(".int8.onnx")

--- a/src/diaremot/pipeline/audio_pipeline_core.py
+++ b/src/diaremot/pipeline/audio_pipeline_core.py
@@ -1,4 +1,3 @@
-
 """Compatibility shim that re-exports the pipeline implementation pieces."""
 
 from __future__ import annotations
@@ -10,7 +9,14 @@ from .config import (
     build_pipeline_config,
     dependency_health_summary,
 )
-from .logging_utils import CoreLogger, JSONLWriter, RunStats, StageGuard, _fmt_hms, _fmt_hms_ms
+from .logging_utils import (
+    CoreLogger,
+    JSONLWriter,
+    RunStats,
+    StageGuard,
+    _fmt_hms,
+    _fmt_hms_ms,
+)
 from .orchestrator import (
     AudioAnalysisPipelineV2,
     clear_pipeline_cache,

--- a/src/diaremot/pipeline/audio_preprocessing.py
+++ b/src/diaremot/pipeline/audio_preprocessing.py
@@ -144,9 +144,7 @@ def _load_uncompressed_with_soundfile(
     if mono and y.ndim > 1:
         y = np.mean(y, axis=1)
     if sr != target_sr:
-        y = librosa.resample(
-            y, orig_sr=sr, target_sr=target_sr, res_type="kaiser_best"
-        )
+        y = librosa.resample(y, orig_sr=sr, target_sr=target_sr, res_type="kaiser_best")
         sr = target_sr
     return y.astype(np.float32), sr
 
@@ -283,7 +281,12 @@ def _get_audio_duration(path: str, info: Optional[sf.Info] = None) -> float:
             duration = float(result.stdout.strip())
             logger.debug(f"Got duration via ffprobe: {duration}s")
             return duration
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError, ValueError) as exc_probe:
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+        ValueError,
+    ) as exc_probe:
         logger.debug(f"ffprobe failed for duration: {exc_probe}")
 
     logger.warning(f"Could not determine duration for {path}, using 0.0")
@@ -327,7 +330,9 @@ def _create_audio_chunks(
     else:
         sr = int(config.target_sr)
 
-    logger.info(f"[chunks] Audio duration: {duration / 60:.1f} minutes; threshold={config.chunk_threshold_minutes} min; size={config.chunk_size_minutes} min; overlap={config.chunk_overlap_seconds}s")
+    logger.info(
+        f"[chunks] Audio duration: {duration / 60:.1f} minutes; threshold={config.chunk_threshold_minutes} min; size={config.chunk_size_minutes} min; overlap={config.chunk_overlap_seconds}s"
+    )
 
     chunk_duration = config.chunk_size_minutes * 60.0
     overlap_duration = config.chunk_overlap_seconds
@@ -362,25 +367,43 @@ def _create_audio_chunks(
         try:
             t0 = time.time()
             # Try direct chunk extraction with ffmpeg (faster for M4A)
-            temp_chunk_raw = tempfile.NamedTemporaryFile(suffix='.wav', delete=False)
+            temp_chunk_raw = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
             temp_chunk_raw.close()
 
             cmd = [
-                'ffmpeg', '-y', '-i', audio_path,
-                '-ss', str(actual_start), '-t', str(actual_end - actual_start),
-                '-acodec', 'pcm_s16le', '-ar', str(sr), '-ac', '1',
-                '-loglevel', 'quiet',
-                temp_chunk_raw.name
+                "ffmpeg",
+                "-y",
+                "-i",
+                audio_path,
+                "-ss",
+                str(actual_start),
+                "-t",
+                str(actual_end - actual_start),
+                "-acodec",
+                "pcm_s16le",
+                "-ar",
+                str(sr),
+                "-ac",
+                "1",
+                "-loglevel",
+                "quiet",
+                temp_chunk_raw.name,
             ]
 
             result = subprocess.run(cmd, capture_output=True, timeout=120)
             if result.returncode == 0:
-                chunk_audio, _ = sf.read(temp_chunk_raw.name, dtype='float32')
-                logger.info(f"[chunks] Extracted chunk {chunk_id} via ffmpeg in {time.time()-t0:.2f}s ({actual_start:.1f}s→{actual_end:.1f}s)")
+                chunk_audio, _ = sf.read(temp_chunk_raw.name, dtype="float32")
+                logger.info(
+                    f"[chunks] Extracted chunk {chunk_id} via ffmpeg in {time.time() - t0:.2f}s ({actual_start:.1f}s→{actual_end:.1f}s)"
+                )
             else:
                 raise subprocess.CalledProcessError(result.returncode, cmd)
 
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        except (
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+            FileNotFoundError,
+        ):
             if info and _is_uncompressed_pcm(info):
                 logger.debug(
                     f"ffmpeg chunk extraction failed; reading PCM chunk via soundfile for chunk {chunk_id}"
@@ -395,7 +418,7 @@ def _create_audio_chunks(
                     chunk_audio = np.mean(chunk_audio, axis=1)
                 chunk_audio = chunk_audio.astype(np.float32, copy=False)
                 logger.info(
-                    f"[chunks] Extracted chunk {chunk_id} via soundfile in {time.time()-t0:.2f}s ({actual_start:.1f}s→{actual_end:.1f}s)"
+                    f"[chunks] Extracted chunk {chunk_id} via soundfile in {time.time() - t0:.2f}s ({actual_start:.1f}s→{actual_end:.1f}s)"
                 )
             else:
                 raise RuntimeError(
@@ -427,7 +450,9 @@ def _create_audio_chunks(
         )
         chunks.append(chunk_info)
 
-        logger.info(f"[chunks] Saved chunk {chunk_id}: {chunk_filename} ({chunk_info.duration:.1f}s)")
+        logger.info(
+            f"[chunks] Saved chunk {chunk_id}: {chunk_filename} ({chunk_info.duration:.1f}s)"
+        )
 
         # Move to next chunk
         start_time = end_time

--- a/src/diaremot/pipeline/cli_entry.py
+++ b/src/diaremot/pipeline/cli_entry.py
@@ -8,7 +8,11 @@ from pathlib import Path
 from typing import Any
 
 from .config import build_pipeline_config
-from .orchestrator import AudioAnalysisPipelineV2, clear_pipeline_cache, config_verify_dependencies
+from .orchestrator import (
+    AudioAnalysisPipelineV2,
+    clear_pipeline_cache,
+    config_verify_dependencies,
+)
 from .speaker_diarization import DiarizationConfig
 
 
@@ -100,7 +104,9 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="Path to intent classifier model assets",
     )
     parser.add_argument("--beam-size", type=int, default=1, help="ASR beam search size")
-    parser.add_argument("--temperature", type=float, default=0.0, help="ASR decoding temperature")
+    parser.add_argument(
+        "--temperature", type=float, default=0.0, help="ASR decoding temperature"
+    )
     parser.add_argument(
         "--no-speech-threshold",
         type=float,
@@ -229,7 +235,9 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _args_to_config(args: argparse.Namespace, *, ignore_tx_cache: bool) -> dict[str, Any]:
+def _args_to_config(
+    args: argparse.Namespace, *, ignore_tx_cache: bool
+) -> dict[str, Any]:
     return {
         "registry_path": args.registry_path,
         "ahc_distance_threshold": args.ahc_distance_threshold,
@@ -270,7 +278,9 @@ def _args_to_config(args: argparse.Namespace, *, ignore_tx_cache: bool) -> dict[
     }
 
 
-def _handle_cache_clear(requested: bool, *, cache_root: Path, ignore_tx_cache: bool) -> bool:
+def _handle_cache_clear(
+    requested: bool, *, cache_root: Path, ignore_tx_cache: bool
+) -> bool:
     if not requested:
         return ignore_tx_cache
     try:
@@ -278,7 +288,9 @@ def _handle_cache_clear(requested: bool, *, cache_root: Path, ignore_tx_cache: b
         print("Cache cleared successfully.")
         return True
     except PermissionError:
-        print("Warning: Could not fully clear cache due to permissions. Ignoring cached results.")
+        print(
+            "Warning: Could not fully clear cache due to permissions. Ignoring cached results."
+        )
         return True
     except RuntimeError as exc:
         print(f"Warning: Cache clear failed: {exc}. Ignoring cached results.")
@@ -295,7 +307,9 @@ def main(argv: list[str] | None = None) -> int:
     if args.verify_deps:
         ok, problems = config_verify_dependencies(bool(args.strict_dependency_versions))
         if ok:
-            suffix = " with required versions" if args.strict_dependency_versions else ""
+            suffix = (
+                " with required versions" if args.strict_dependency_versions else ""
+            )
             print(f"All core dependencies are importable{suffix}.")
             return 0
         print("Dependency verification failed\n  - " + "\n  - ".join(problems))

--- a/src/diaremot/pipeline/config.py
+++ b/src/diaremot/pipeline/config.py
@@ -102,7 +102,9 @@ class PipelineConfig:
         self.log_dir = Path(self.log_dir)
         self.checkpoint_dir = Path(self.checkpoint_dir)
         self.affect_text_model_dir = _coerce_optional_path(self.affect_text_model_dir)
-        self.affect_intent_model_dir = _coerce_optional_path(self.affect_intent_model_dir)
+        self.affect_intent_model_dir = _coerce_optional_path(
+            self.affect_intent_model_dir
+        )
 
         if isinstance(self.cache_roots, (str, Path)):
             self.cache_roots = [Path(self.cache_roots)]
@@ -110,15 +112,25 @@ class PipelineConfig:
             self.cache_roots = [Path(path) for path in (self.cache_roots or [])]
 
         if self.intent_labels is not None:
-            if not isinstance(self.intent_labels, Iterable) or isinstance(self.intent_labels, (str, bytes)):
+            if not isinstance(self.intent_labels, Iterable) or isinstance(
+                self.intent_labels, (str, bytes)
+            ):
                 raise ValueError("intent_labels must be an iterable of strings")
             self.intent_labels = [str(label) for label in self.intent_labels]
 
-        self.affect_backend = self._lower_choice("affect_backend", self.affect_backend, {"auto", "onnx", "torch"})
+        self.affect_backend = self._lower_choice(
+            "affect_backend", self.affect_backend, {"auto", "onnx", "torch"}
+        )
         self.asr_backend = self._lower_choice("asr_backend", self.asr_backend, None)
-        self.vad_backend = self._lower_choice("vad_backend", self.vad_backend, {"auto", "onnx", "torch"})
-        self.loudness_mode = self._lower_choice("loudness_mode", self.loudness_mode, {"asr", "broadcast"})
-        self.language_mode = self._lower_choice("language_mode", self.language_mode, None)
+        self.vad_backend = self._lower_choice(
+            "vad_backend", self.vad_backend, {"auto", "onnx", "torch"}
+        )
+        self.loudness_mode = self._lower_choice(
+            "loudness_mode", self.loudness_mode, {"asr", "broadcast"}
+        )
+        self.language_mode = self._lower_choice(
+            "language_mode", self.language_mode, None
+        )
 
         if self.speaker_limit is not None and self.speaker_limit < 1:
             raise ValueError("speaker_limit must be >= 1 or None")
@@ -126,12 +138,18 @@ class PipelineConfig:
         self._validate_positive_int("cpu_threads", self.cpu_threads)
         self._validate_positive_int("beam_size", self.beam_size)
         self._validate_positive_int("max_asr_window_sec", self.max_asr_window_sec)
-        self._validate_positive_float("chunk_threshold_minutes", self.chunk_threshold_minutes)
+        self._validate_positive_float(
+            "chunk_threshold_minutes", self.chunk_threshold_minutes
+        )
         self._validate_positive_float("chunk_size_minutes", self.chunk_size_minutes)
-        _ensure_numeric_range("chunk_overlap_seconds", self.chunk_overlap_seconds, ge=0.0)
+        _ensure_numeric_range(
+            "chunk_overlap_seconds", self.chunk_overlap_seconds, ge=0.0
+        )
         _ensure_numeric_range("vad_threshold", self.vad_threshold, ge=0.0, le=1.0)
         _ensure_numeric_range("temperature", self.temperature, ge=0.0, le=1.0)
-        _ensure_numeric_range("no_speech_threshold", self.no_speech_threshold, ge=0.0, le=1.0)
+        _ensure_numeric_range(
+            "no_speech_threshold", self.no_speech_threshold, ge=0.0, le=1.0
+        )
         _ensure_numeric_range("vad_min_speech_sec", self.vad_min_speech_sec, ge=0.0)
         _ensure_numeric_range("vad_min_silence_sec", self.vad_min_silence_sec, ge=0.0)
         _ensure_numeric_range("vad_speech_pad_sec", self.vad_speech_pad_sec, ge=0.0)
@@ -139,10 +157,14 @@ class PipelineConfig:
         _ensure_numeric_range("segment_timeout_sec", self.segment_timeout_sec, gt=0.0)
         _ensure_numeric_range("batch_timeout_sec", self.batch_timeout_sec, gt=0.0)
         self._validate_positive_int("target_sr", self.target_sr)
-        _ensure_numeric_range("ahc_distance_threshold", self.ahc_distance_threshold, ge=0.0)
+        _ensure_numeric_range(
+            "ahc_distance_threshold", self.ahc_distance_threshold, ge=0.0
+        )
 
         if self.chunk_size_minutes * 60.0 <= self.chunk_overlap_seconds:
-            raise ValueError("chunk_overlap_seconds must be smaller than chunk_size_minutes * 60")
+            raise ValueError(
+                "chunk_overlap_seconds must be smaller than chunk_size_minutes * 60"
+            )
         if self.chunk_threshold_minutes < self.chunk_size_minutes:
             raise ValueError("chunk_threshold_minutes must be >= chunk_size_minutes")
 
@@ -176,7 +198,9 @@ class PipelineConfig:
         return data
 
     @classmethod
-    def model_validate(cls, data: Mapping[str, Any] | "PipelineConfig") -> "PipelineConfig":
+    def model_validate(
+        cls, data: Mapping[str, Any] | "PipelineConfig"
+    ) -> "PipelineConfig":
         """Validate a mapping and construct a configuration instance."""
 
         if isinstance(data, PipelineConfig):
@@ -212,7 +236,9 @@ __all__ = [
 ]
 
 
-def build_pipeline_config(overrides: dict[str, Any] | PipelineConfig | None = None) -> dict[str, Any]:
+def build_pipeline_config(
+    overrides: dict[str, Any] | PipelineConfig | None = None,
+) -> dict[str, Any]:
     """Return a validated pipeline configuration merged with overrides."""
 
     if isinstance(overrides, PipelineConfig):
@@ -232,12 +258,17 @@ def build_pipeline_config(overrides: dict[str, Any] | PipelineConfig | None = No
 
     try:
         validated = PipelineConfig.model_validate(merged)
-    except (TypeError, ValueError) as exc:  # pragma: no cover - surface readable error upstream
+    except (
+        TypeError,
+        ValueError,
+    ) as exc:  # pragma: no cover - surface readable error upstream
         raise ValueError(str(exc)) from exc
     return validated.model_dump(mode="python")
 
 
-def _iter_dependency_status() -> Iterator[tuple[str, str, Any, str | None, Exception | None, Exception | None]]:
+def _iter_dependency_status() -> Iterator[
+    tuple[str, str, Any, str | None, Exception | None, Exception | None]
+]:
     for mod, min_ver in CORE_DEPENDENCY_REQUIREMENTS.items():
         import_error: Exception | None = None
         metadata_error: Exception | None = None
@@ -261,7 +292,14 @@ def _iter_dependency_status() -> Iterator[tuple[str, str, Any, str | None, Excep
 def _verify_core_dependencies(require_versions: bool = False) -> tuple[bool, list[str]]:
     issues: list[str] = []
 
-    for mod, min_ver, module, version, import_error, metadata_error in _iter_dependency_status():
+    for (
+        mod,
+        min_ver,
+        module,
+        version,
+        import_error,
+        metadata_error,
+    ) in _iter_dependency_status():
         if import_error is not None or module is None:
             issues.append(f"Missing or failed to import: {mod} ({import_error})")
             continue
@@ -289,7 +327,14 @@ def _verify_core_dependencies(require_versions: bool = False) -> tuple[bool, lis
 def dependency_health_summary() -> dict[str, dict[str, Any]]:
     summary: dict[str, dict[str, Any]] = {}
 
-    for mod, min_ver, module, version, import_error, metadata_error in _iter_dependency_status():
+    for (
+        mod,
+        min_ver,
+        module,
+        version,
+        import_error,
+        metadata_error,
+    ) in _iter_dependency_status():
         entry: dict[str, Any] = {"required_min": min_ver}
 
         if import_error is not None or module is None:

--- a/src/diaremot/pipeline/cpu_optimized_diarizer.py
+++ b/src/diaremot/pipeline/cpu_optimized_diarizer.py
@@ -70,7 +70,10 @@ class CPUOptimizedSpeakerDiarizer:
             last = merged[-1]
             if seg["start"] <= last["end"] and seg["speaker"] == last["speaker"]:
                 last["end"] = max(last["end"], seg["end"])
-                if seg.get("embedding") is not None and last.get("embedding") is not None:
+                if (
+                    seg.get("embedding") is not None
+                    and last.get("embedding") is not None
+                ):
                     last_emb = np.asarray(last["embedding"], dtype=np.float32)
                     seg_emb = np.asarray(seg["embedding"], dtype=np.float32)
                     last["embedding"] = np.mean([last_emb, seg_emb], axis=0).tolist()
@@ -97,7 +100,10 @@ class CPUOptimizedSpeakerDiarizer:
             for start, end in self._chunks(audio, sr):
                 chunk = audio[start:end]
 
-                if self.config.enable_vad and self._rms_db(chunk) < self.config.energy_threshold_db:
+                if (
+                    self.config.enable_vad
+                    and self._rms_db(chunk) < self.config.energy_threshold_db
+                ):
                     continue
 
                 offset = start / sr
@@ -108,7 +114,9 @@ class CPUOptimizedSpeakerDiarizer:
                 elif isinstance(result, (list, tuple)):
                     result_iter = result
                 else:
-                    self.logger.debug(f"Skipping unexpected diarize result type: {type(result)}")
+                    self.logger.debug(
+                        f"Skipping unexpected diarize result type: {type(result)}"
+                    )
                     result_iter = []
 
                 for seg in result_iter:
@@ -119,7 +127,9 @@ class CPUOptimizedSpeakerDiarizer:
                             s = dict(vars(seg))
                         else:
                             # Unsupported type (e.g., str); skip gracefully
-                            self.logger.debug(f"Skipping unexpected segment type: {type(seg)}")
+                            self.logger.debug(
+                                f"Skipping unexpected segment type: {type(seg)}"
+                            )
                             continue
 
                         # Normalize required fields
@@ -156,7 +166,9 @@ class CPUOptimizedSpeakerDiarizer:
                         )
                     else:
                         clusterer = _agglo(
-                            distance_threshold=getattr(cfg, "ahc_distance_threshold", 0.12),
+                            distance_threshold=getattr(
+                                cfg, "ahc_distance_threshold", 0.12
+                            ),
                             linkage=getattr(cfg, "ahc_linkage", "average"),
                             metric="cosine",
                         )

--- a/src/diaremot/pipeline/dependency_checks.py
+++ b/src/diaremot/pipeline/dependency_checks.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from importlib import metadata as importlib_metadata
-from typing import Any, Iterable, Iterator
+from typing import Any, Iterator
 
 try:  # pragma: no cover - packaging may not be installed in some runtimes
     from packaging.version import Version
@@ -13,7 +13,9 @@ except Exception:  # pragma: no cover - fallback if packaging missing
 from .pipeline_config import CORE_DEPENDENCY_REQUIREMENTS
 
 
-def _iter_dependency_status() -> Iterator[tuple[str, str, Any, str | None, Exception | None, Exception | None]]:
+def _iter_dependency_status() -> Iterator[
+    tuple[str, str, Any, str | None, Exception | None, Exception | None]
+]:
     for mod, min_ver in CORE_DEPENDENCY_REQUIREMENTS.items():
         import_error: Exception | None = None
         metadata_error: Exception | None = None
@@ -39,7 +41,14 @@ def _verify_core_dependencies(require_versions: bool = False) -> tuple[bool, lis
 
     issues: list[str] = []
 
-    for mod, min_ver, module, version, import_error, metadata_error in _iter_dependency_status():
+    for (
+        mod,
+        min_ver,
+        module,
+        version,
+        import_error,
+        metadata_error,
+    ) in _iter_dependency_status():
         if import_error is not None or module is None:
             issues.append(f"Missing or failed to import: {mod} ({import_error})")
             continue
@@ -67,7 +76,14 @@ def _verify_core_dependencies(require_versions: bool = False) -> tuple[bool, lis
 def _dependency_health_summary() -> dict[str, dict[str, Any]]:
     summary: dict[str, dict[str, Any]] = {}
 
-    for mod, min_ver, module, version, import_error, metadata_error in _iter_dependency_status():
+    for (
+        mod,
+        min_ver,
+        module,
+        version,
+        import_error,
+        metadata_error,
+    ) in _iter_dependency_status():
         entry: dict[str, Any] = {"required_min": min_ver}
 
         if import_error is not None or module is None:
@@ -129,4 +145,3 @@ __all__ = [
     "diagnostics",
     "verify_dependencies",
 ]
-

--- a/src/diaremot/pipeline/diagnostics_smoke.py
+++ b/src/diaremot/pipeline/diagnostics_smoke.py
@@ -101,7 +101,9 @@ def prepare_smoke_wav(
 
         sf.write(wav_path, audio, sample_rate)
     except Exception as exc:  # pragma: no cover - optional dependency
-        raise RuntimeError("soundfile is required to prepare diagnostics audio") from exc
+        raise RuntimeError(
+            "soundfile is required to prepare diagnostics audio"
+        ) from exc
     return wav_path
 
 
@@ -159,4 +161,3 @@ __all__ = [
     "run_pipeline_smoke_test",
     "silence_audio_factory",
 ]
-

--- a/src/diaremot/pipeline/outputs.py
+++ b/src/diaremot/pipeline/outputs.py
@@ -140,14 +140,21 @@ def write_qc_report(
         "config_snapshot": stats.config_snapshot,
         "audio_health": {
             "snr_db": float(getattr(health, "snr_db", 0.0)) if health else None,
-            "silence_ratio": float(getattr(health, "silence_ratio", 0.0)) if health else None,
-            "clipping_detected": bool(getattr(health, "clipping_detected", False)) if health else None,
-            "dynamic_range_db": float(getattr(health, "dynamic_range_db", 0.0)) if health else None,
+            "silence_ratio": float(getattr(health, "silence_ratio", 0.0))
+            if health
+            else None,
+            "clipping_detected": bool(getattr(health, "clipping_detected", False))
+            if health
+            else None,
+            "dynamic_range_db": float(getattr(health, "dynamic_range_db", 0.0))
+            if health
+            else None,
         },
         "counts": {"turns": int(n_turns), "segments": int(n_segments)},
     }
 
     try:
+
         def _avg(key: str) -> float | None:
             values = []
             for seg in segments or []:

--- a/src/diaremot/pipeline/pipeline_checkpoint_system.py
+++ b/src/diaremot/pipeline/pipeline_checkpoint_system.py
@@ -143,7 +143,9 @@ class PipelineCheckpointManager:
         self, audio_file: str, stage: ProcessingStage, file_hash: Optional[str] = None
     ) -> Path:
         """Get metadata file path"""
-        checkpoint_path = self._get_checkpoint_path(audio_file, stage, file_hash=file_hash)
+        checkpoint_path = self._get_checkpoint_path(
+            audio_file, stage, file_hash=file_hash
+        )
         return checkpoint_path.with_suffix(".meta")
 
     def create_checkpoint(
@@ -187,7 +189,9 @@ class PipelineCheckpointManager:
                 # Save metadata (convert enum to string for JSON serialization)
                 with open(metadata_path, "w") as f:
                     metadata_dict = asdict(metadata)
-                    metadata_dict['stage'] = metadata.stage.value  # Convert enum to string
+                    metadata_dict["stage"] = (
+                        metadata.stage.value
+                    )  # Convert enum to string
                     json.dump(metadata_dict, f, indent=2)
 
                 self.logger.info(f"Checkpoint created: {stage.value} ({progress:.1f}%)")

--- a/src/diaremot/pipeline/pipeline_config.py
+++ b/src/diaremot/pipeline/pipeline_config.py
@@ -106,4 +106,3 @@ __all__ = [
     "build_pipeline_config",
     "clear_pipeline_cache",
 ]
-

--- a/src/diaremot/pipeline/pipeline_diagnostic.py
+++ b/src/diaremot/pipeline/pipeline_diagnostic.py
@@ -25,6 +25,7 @@ def _module_available(module_name: str) -> bool:
 
     return importlib.util.find_spec(module_name) is not None
 
+
 class PipelineDiagnostic:
     def __init__(self):
         self.issues = []
@@ -90,13 +91,15 @@ class PipelineDiagnostic:
         cache_dir = Path(".cache")
         if not cache_dir.exists():
             return True, "No cache directory found (clean state)"
-        
+
         cache_files = list(cache_dir.rglob("*.json"))
         if cache_files:
-            self.warnings.append(f"Found {len(cache_files)} cache files that may prevent fresh processing")
+            self.warnings.append(
+                f"Found {len(cache_files)} cache files that may prevent fresh processing"
+            )
             return False, f"Cache files present: {len(cache_files)} files"
         return True, "Cache directory empty"
-    
+
     def clear_cache(self) -> bool:
         """Clear all cache files"""
         try:
@@ -110,7 +113,7 @@ class PipelineDiagnostic:
         except Exception as e:
             self.issues.append(f"Failed to clear cache: {e}")
             return False
-    
+
     def check_audio_dependencies(self) -> Tuple[bool, str]:
         """Check audio processing dependencies"""
         issues, warnings = self._summarize_modules(
@@ -125,10 +128,7 @@ class PipelineDiagnostic:
 
         try:
             result = subprocess.run(
-                ["ffmpeg", "-version"],
-                capture_output=True,
-                text=True,
-                timeout=5
+                ["ffmpeg", "-version"], capture_output=True, text=True, timeout=5
             )
             if result.returncode != 0:
                 issues.append("ffmpeg not working properly")
@@ -181,13 +181,20 @@ class PipelineDiagnostic:
                     fixed = True
             except Exception as e:
                 self.warnings.append(f"Could not reinstall {package}: {e}")
-        
+
         return fixed
-    
+
     def check_model_dependencies(self) -> Tuple[bool, str]:
         """Check ML model dependencies"""
         issues, warnings = self._summarize_modules(
-            ("torch", "ctranslate2", "faster_whisper", "onnxruntime", "transformers", "pandas"),
+            (
+                "torch",
+                "ctranslate2",
+                "faster_whisper",
+                "onnxruntime",
+                "transformers",
+                "pandas",
+            ),
             warn_is_issue=True,
         )
 
@@ -198,179 +205,192 @@ class PipelineDiagnostic:
             self.issues.extend(issues)
             return False, f"Model dependencies issues: {', '.join(issues)}"
         return True, "Model dependencies OK"
-    
+
     def check_pipeline_config(self) -> Tuple[bool, str]:
         """Check pipeline configuration"""
         config_file = Path("pipeline_config.json")
-        
+
         if not config_file.exists():
             self.warnings.append("No pipeline_config.json found (using defaults)")
             return True, "Using default configuration"
-        
+
         try:
             with open(config_file) as f:
                 config = json.load(f)
-            
+
             # Check for common misconfigurations
             if config.get("device") == "cuda" and not self._cuda_available():
                 self.warnings.append("Config specifies CUDA but GPU not available")
-            
+
             return True, "Configuration loaded successfully"
         except Exception as e:
             self.issues.append(f"Config file error: {e}")
             return False, f"Configuration error: {e}"
-    
+
     def _cuda_available(self) -> bool:
         """Check if CUDA is available"""
         try:
             import torch
+
             return torch.cuda.is_available()
         except Exception:
             return False
-    
+
     def run_diagnostics(self) -> Dict:
         """Run all diagnostics"""
-        print("="*60)
+        print("=" * 60)
         print("PIPELINE DIAGNOSTIC TOOL")
-        print("="*60)
+        print("=" * 60)
         print("\nRunning diagnostics...")
-        print("-"*40)
-        
+        print("-" * 40)
+
         results = {}
-        
+
         # Check cache
         cache_ok, cache_msg = self.check_cache_issues()
-        results['cache'] = {'ok': cache_ok, 'message': cache_msg}
+        results["cache"] = {"ok": cache_ok, "message": cache_msg}
         print(f"{'✓' if cache_ok else '✗'} Cache: {cache_msg}")
-        
+
         # Check audio deps
         audio_ok, audio_msg = self.check_audio_dependencies()
-        results['audio'] = {'ok': audio_ok, 'message': audio_msg}
+        results["audio"] = {"ok": audio_ok, "message": audio_msg}
         print(f"{'✓' if audio_ok else '✗'} Audio: {audio_msg}")
-        
+
         # Check model deps
         model_ok, model_msg = self.check_model_dependencies()
-        results['models'] = {'ok': model_ok, 'message': model_msg}
+        results["models"] = {"ok": model_ok, "message": model_msg}
         print(f"{'✓' if model_ok else '✗'} Models: {model_msg}")
-        
+
         # Check config
         config_ok, config_msg = self.check_pipeline_config()
-        results['config'] = {'ok': config_ok, 'message': config_msg}
+        results["config"] = {"ok": config_ok, "message": config_msg}
         print(f"{'✓' if config_ok else '✗'} Config: {config_msg}")
-        
+
         return results
-    
+
     def apply_fixes(self) -> bool:
         """Apply automatic fixes"""
-        print("\n" + "="*60)
+        print("\n" + "=" * 60)
         print("APPLYING FIXES")
-        print("-"*40)
-        
+        print("-" * 40)
+
         any_fixed = False
-        
+
         # Clear cache if needed
         if any("cache" in issue.lower() for issue in self.issues + self.warnings):
             print("Clearing cache...")
             if self.clear_cache():
                 print("  ✓ Cache cleared")
                 any_fixed = True
-        
+
         # Fix audio dependencies if needed
-        if any("audio" in issue.lower() or "soundfile" in issue.lower() 
-               for issue in self.issues):
+        if any(
+            "audio" in issue.lower() or "soundfile" in issue.lower()
+            for issue in self.issues
+        ):
             print("Fixing audio dependencies...")
             if self.fix_audio_dependencies():
                 print("  ✓ Audio dependencies updated")
                 any_fixed = True
-        
+
         return any_fixed
-    
+
     def generate_report(self, results: Dict) -> None:
         """Generate diagnostic report"""
-        print("\n" + "="*60)
+        print("\n" + "=" * 60)
         print("DIAGNOSTIC REPORT")
-        print("-"*40)
-        
-        all_ok = all(r['ok'] for r in results.values())
-        
+        print("-" * 40)
+
+        all_ok = all(r["ok"] for r in results.values())
+
         if self.issues:
             print("\n❌ CRITICAL ISSUES:")
             for issue in self.issues:
                 print(f"  • {issue}")
-        
+
         if self.warnings:
             print("\n⚠️  WARNINGS:")
             for warning in self.warnings:
                 print(f"  • {warning}")
-        
+
         if self.fixes_applied:
             print("\n✅ FIXES APPLIED:")
             for fix in self.fixes_applied:
                 print(f"  • {fix}")
-        
-        print("\n" + "="*60)
+
+        print("\n" + "=" * 60)
         if all_ok and not self.issues:
             print("✓ PIPELINE READY - All checks passed!")
         else:
             print("⚠ ISSUES DETECTED - Review above and apply manual fixes if needed")
             print("\nSuggested manual fixes:")
-            
+
             if any("ffmpeg" in issue.lower() for issue in self.issues):
                 print("1. Install FFmpeg:")
                 print("   • Download from: https://ffmpeg.org/download.html")
                 print("   • Add to system PATH")
-            
+
             if any("soundfile" in issue.lower() for issue in self.issues):
                 print("2. Install libsndfile (Windows):")
                 print("   • Via conda: conda install -c conda-forge libsndfile")
-                print("   • Or download from: https://github.com/libsndfile/libsndfile/releases")
-        
+                print(
+                    "   • Or download from: https://github.com/libsndfile/libsndfile/releases"
+                )
+
         # Save report to file
         report_path = Path("diagnostic_report.json")
         with open(report_path, "w") as f:
-            json.dump({
-                "results": results,
-                "issues": self.issues,
-                "warnings": self.warnings,
-                "fixes_applied": self.fixes_applied
-            }, f, indent=2)
-        
+            json.dump(
+                {
+                    "results": results,
+                    "issues": self.issues,
+                    "warnings": self.warnings,
+                    "fixes_applied": self.fixes_applied,
+                },
+                f,
+                indent=2,
+            )
+
         print(f"\nDetailed report saved to: {report_path}")
+
 
 def main():
     diagnostic = PipelineDiagnostic()
-    
+
     # Run diagnostics
     results = diagnostic.run_diagnostics()
-    
+
     # Apply fixes if needed
     if diagnostic.issues:
         response = input("\nApply automatic fixes? (y/n): ").lower()
-        if response == 'y':
+        if response == "y":
             diagnostic.apply_fixes()
-            
+
             # Re-run diagnostics
             print("\nRe-running diagnostics after fixes...")
             diagnostic = PipelineDiagnostic()
             results = diagnostic.run_diagnostics()
-    
+
     # Generate report
     diagnostic.generate_report(results)
-    
+
     # Offer to run test
     if not diagnostic.issues:
         response = input("\nRun a test audio processing? (y/n): ").lower()
-        if response == 'y':
+        if response == "y":
             print("\nRunning test...")
             try:
-                subprocess.run([
-                    sys.executable,
-                    "-m",
-                    "diaremot.pipeline.audio_pipeline_core",
-                    "--verify_deps"
-                ])
+                subprocess.run(
+                    [
+                        sys.executable,
+                        "-m",
+                        "diaremot.pipeline.audio_pipeline_core",
+                        "--verify_deps",
+                    ]
+                )
             except Exception as e:
                 print(f"Test failed: {e}")
+
 
 if __name__ == "__main__":
     main()

--- a/src/diaremot/pipeline/pipeline_healthcheck.py
+++ b/src/diaremot/pipeline/pipeline_healthcheck.py
@@ -111,9 +111,15 @@ def run_smoke_test() -> Dict[str, str]:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="DiaRemo pipeline health check")
-    parser.add_argument("--skip-models", action="store_true", help="skip model availability checks")
-    parser.add_argument("--skip-smoke", action="store_true", help="skip running the pipeline smoke test")
-    parser.add_argument("--local-only", action="store_true", help="do not download missing models")
+    parser.add_argument(
+        "--skip-models", action="store_true", help="skip model availability checks"
+    )
+    parser.add_argument(
+        "--skip-smoke", action="store_true", help="skip running the pipeline smoke test"
+    )
+    parser.add_argument(
+        "--local-only", action="store_true", help="do not download missing models"
+    )
     args = parser.parse_args()
 
     report = {"dependencies": check_dependencies()}

--- a/src/diaremot/pipeline/provider_registry.py
+++ b/src/diaremot/pipeline/provider_registry.py
@@ -34,4 +34,3 @@ def provide(name: str, *args: Any, **kwargs: Any) -> Any:
 
 
 __all__ = ["register_provider", "get_provider", "provide"]
-

--- a/src/diaremot/pipeline/transcription_module.py
+++ b/src/diaremot/pipeline/transcription_module.py
@@ -1,5 +1,5 @@
 # transcription_module.py
-    # Optimized, async-enabled transcription module with modern Python patterns
+# Optimized, async-enabled transcription module with modern Python patterns
 # Designed for high-throughput pipeline integration
 
 from __future__ import annotations
@@ -483,9 +483,7 @@ class AsyncTranscriber:
                 pass
         try:
             model_concurrency_value = (
-                int(model_concurrency)
-                if model_concurrency is not None
-                else 1
+                int(model_concurrency) if model_concurrency is not None else 1
             )
         except Exception:
             model_concurrency_value = 1

--- a/src/diaremot/pipeline/validate_system_complete.py
+++ b/src/diaremot/pipeline/validate_system_complete.py
@@ -209,14 +209,10 @@ def test_parselmouth():
         if not getattr(para, "PARSELMOUTH_AVAILABLE", False):
             print("⚠ Parselmouth not available")
             return False
-        audio = np.sin(2 * np.pi * 100 * np.linspace(0, 1, 16000)).astype(
-            np.float32
-        )
+        audio = np.sin(2 * np.pi * 100 * np.linspace(0, 1, 16000)).astype(np.float32)
         cfg = para.ParalinguisticsConfig(vq_use_parselmouth=True)
         res = para._compute_voice_quality_parselmouth_v2(audio, 16000, cfg)
-        print(
-            f"✓ Parselmouth functional (jitter_pct={res.get('jitter_pct', 0.0):.3f})"
-        )
+        print(f"✓ Parselmouth functional (jitter_pct={res.get('jitter_pct', 0.0):.3f})")
         return True
     except Exception as e:
         print(f"❌ Parselmouth test failed: {e}")

--- a/src/diaremot/summaries/__init__.py
+++ b/src/diaremot/summaries/__init__.py
@@ -1,4 +1,4 @@
-"""Summary generation utilities and conversation analytics.""" 
+"""Summary generation utilities and conversation analytics."""
 
 __all__ = [
     "conversation_analysis",

--- a/src/diaremot/summaries/conversation_analysis.py
+++ b/src/diaremot/summaries/conversation_analysis.py
@@ -123,7 +123,9 @@ def analyze_conversation_flow(
         # Interruption rate per minute
         try:
             interrupt_rate = (
-                sum(interrupts.values()) / duration_minutes if duration_minutes > 0 else 0.0
+                sum(interrupts.values()) / duration_minutes
+                if duration_minutes > 0
+                else 0.0
             )
             interrupts_per_speaker = {
                 spk: (cnt / duration_minutes if duration_minutes > 0 else 0.0)

--- a/src/diaremot/utils/hash.py
+++ b/src/diaremot/utils/hash.py
@@ -53,4 +53,3 @@ def hash_file(
 
 
 __all__ = ["hash_file"]
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,9 @@ def pytest_configure() -> None:
         np.array = _to_array  # type: ignore[attr-defined]
         np.asarray = _to_array  # type: ignore[attr-defined]
         np.ascontiguousarray = lambda data: data  # type: ignore[attr-defined]
-        np.zeros = lambda shape, dtype=None: [0.0] * (shape if isinstance(shape, int) else int(math.prod(shape)))  # type: ignore[attr-defined]
+        np.zeros = lambda shape, dtype=None: [0.0] * (
+            shape if isinstance(shape, int) else int(math.prod(shape))
+        )  # type: ignore[attr-defined]
         np.float32 = float  # type: ignore[attr-defined]
         np.sqrt = lambda x: math.sqrt(x)  # type: ignore[attr-defined]
         np.mean = lambda arr: (sum(arr) / len(arr)) if arr else 0.0  # type: ignore[attr-defined]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,8 +4,11 @@ from pathlib import Path
 
 import pytest
 
-typer = pytest.importorskip("typer")
-from typer.testing import CliRunner
+try:
+    import typer
+    from typer.testing import CliRunner
+except ModuleNotFoundError:  # pragma: no cover - exercised only without typer installed
+    pytest.skip("typer is required for CLI tests", allow_module_level=True)
 
 # Ensure the src layout is importable when running tests directly from the repo root.
 TESTS_ROOT = Path(__file__).resolve().parents[1]
@@ -28,7 +31,9 @@ def test_cli_requires_input_argument(runner: CliRunner) -> None:
     assert "--input" in result.stdout or "--input" in result.stderr
 
 
-def test_cli_run_invokes_pipeline(monkeypatch: pytest.MonkeyPatch, runner: CliRunner, tmp_path: Path) -> None:
+def test_cli_run_invokes_pipeline(
+    monkeypatch: pytest.MonkeyPatch, runner: CliRunner, tmp_path: Path
+) -> None:
     audio = tmp_path / "call.wav"
     audio.write_text("fake audio")
     outdir = tmp_path / "outputs"
@@ -73,7 +78,9 @@ def test_cli_run_invokes_pipeline(monkeypatch: pytest.MonkeyPatch, runner: CliRu
     assert captured["clear_cache"] is True
 
 
-def test_cli_validates_affect_backend_paths(monkeypatch: pytest.MonkeyPatch, runner: CliRunner, tmp_path: Path) -> None:
+def test_cli_validates_affect_backend_paths(
+    monkeypatch: pytest.MonkeyPatch, runner: CliRunner, tmp_path: Path
+) -> None:
     audio = tmp_path / "call.wav"
     audio.write_text("fake audio")
     outdir = tmp_path / "outputs"
@@ -101,10 +108,15 @@ def test_cli_validates_affect_backend_paths(monkeypatch: pytest.MonkeyPatch, run
     )
 
     assert result.exit_code != 0
-    assert "affect_text_model_dir" in result.stdout or "affect_text_model_dir" in result.stderr
+    assert (
+        "affect_text_model_dir" in result.stdout
+        or "affect_text_model_dir" in result.stderr
+    )
 
 
-def test_diagnostics_entrypoint_accepts_strict(monkeypatch: pytest.MonkeyPatch, runner: CliRunner) -> None:
+def test_diagnostics_entrypoint_accepts_strict(
+    monkeypatch: pytest.MonkeyPatch, runner: CliRunner
+) -> None:
     captured = {}
 
     def fake_core_diagnostics(*, require_versions: bool):

--- a/tests/test_diarization_defaults.py
+++ b/tests/test_diarization_defaults.py
@@ -2,13 +2,18 @@ from pathlib import Path
 
 import pytest
 
-np = pytest.importorskip("numpy")
-if getattr(np, "__stub__", False):
-    pytest.skip("numpy not available", allow_module_level=True)
-
-wavfile = pytest.importorskip("scipy.io").wavfile
+try:
+    import numpy as np
+    from scipy.io import wavfile
+except ModuleNotFoundError:  # pragma: no cover - exercised only when deps missing
+    pytest.skip(
+        "numpy and scipy.io are required for diarization tests", allow_module_level=True
+    )
 
 from diaremot.pipeline import speaker_diarization as sd
+
+if getattr(np, "__stub__", False) or not hasattr(np, "array"):
+    pytest.skip("numpy not available", allow_module_level=True)
 
 
 def test_default_threshold_merges_single_speaker(monkeypatch):

--- a/tests/test_pipeline_cli_entry_module.py
+++ b/tests/test_pipeline_cli_entry_module.py
@@ -11,16 +11,18 @@ from diaremot.pipeline import cli_entry
 
 def test_args_to_config_includes_flags() -> None:
     parser = cli_entry._build_arg_parser()
-    args = parser.parse_args([
-        "--input",
-        "sample.wav",
-        "--outdir",
-        "out",
-        "--beam-size",
-        "3",
-        "--no-speech-threshold",
-        "0.25",
-    ])
+    args = parser.parse_args(
+        [
+            "--input",
+            "sample.wav",
+            "--outdir",
+            "out",
+            "--beam-size",
+            "3",
+            "--no-speech-threshold",
+            "0.25",
+        ]
+    )
     config = cli_entry._args_to_config(args, ignore_tx_cache=True)
     assert config["beam_size"] == 3
     assert config["no_speech_threshold"] == 0.25
@@ -29,40 +31,48 @@ def test_args_to_config_includes_flags() -> None:
 
 def test_args_to_config_handles_chunk_toggle() -> None:
     parser = cli_entry._build_arg_parser()
-    args = parser.parse_args([
-        "--input",
-        "sample.wav",
-        "--outdir",
-        "out",
-        "--no-chunk-enabled",
-    ])
+    args = parser.parse_args(
+        [
+            "--input",
+            "sample.wav",
+            "--outdir",
+            "out",
+            "--no-chunk-enabled",
+        ]
+    )
     config = cli_entry._args_to_config(args, ignore_tx_cache=False)
     assert config["auto_chunk_enabled"] is False
 
+
 def test_args_to_config_defaults_preserve_chunking() -> None:
     parser = cli_entry._build_arg_parser()
-    args = parser.parse_args([
-        "--input",
-        "sample.wav",
-        "--outdir",
-        "out",
-    ])
+    args = parser.parse_args(
+        [
+            "--input",
+            "sample.wav",
+            "--outdir",
+            "out",
+        ]
+    )
     config = cli_entry._args_to_config(args, ignore_tx_cache=False)
     assert config["auto_chunk_enabled"] is True
 
 
 def test_args_to_config_accepts_affect_backend_auto() -> None:
     parser = cli_entry._build_arg_parser()
-    args = parser.parse_args([
-        "--input",
-        "sample.wav",
-        "--outdir",
-        "out",
-        "--affect-backend",
-        "auto",
-    ])
+    args = parser.parse_args(
+        [
+            "--input",
+            "sample.wav",
+            "--outdir",
+            "out",
+            "--affect-backend",
+            "auto",
+        ]
+    )
     config = cli_entry._args_to_config(args, ignore_tx_cache=False)
     assert config["affect_backend"] == "auto"
+
 
 def test_main_verify_deps(monkeypatch: pytest.MonkeyPatch, capsys: Any) -> None:
     called = {}
@@ -79,7 +89,9 @@ def test_main_verify_deps(monkeypatch: pytest.MonkeyPatch, capsys: Any) -> None:
     assert "All core dependencies" in captured.out
 
 
-def test_main_runs_pipeline(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: Any) -> None:
+def test_main_runs_pipeline(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: Any
+) -> None:
     audio = tmp_path / "call.wav"
     audio.write_text("fake")
     outdir = tmp_path / "out"
@@ -97,13 +109,15 @@ def test_main_runs_pipeline(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, cap
 
     monkeypatch.setattr(cli_entry, "AudioAnalysisPipelineV2", DummyPipeline)
 
-    exit_code = cli_entry.main([
-        "--input",
-        str(audio),
-        "--outdir",
-        str(outdir),
-        "--clear-cache",
-    ])
+    exit_code = cli_entry.main(
+        [
+            "--input",
+            str(audio),
+            "--outdir",
+            str(outdir),
+            "--clear-cache",
+        ]
+    )
 
     assert exit_code == 0
     raw_output = capsys.readouterr().out.splitlines()

--- a/tests/test_pipeline_config_module.py
+++ b/tests/test_pipeline_config_module.py
@@ -21,8 +21,12 @@ def test_build_pipeline_config_merges_and_validates() -> None:
     assert build_pipeline_config(cfg)["beam_size"] == 2
 
 
-def test_dependency_summary_handles_import_errors(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_iter() -> Iterator[Tuple[str, str, object | None, str | None, Exception | None, Exception | None]]:
+def test_dependency_summary_handles_import_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_iter() -> Iterator[
+        Tuple[str, str, object | None, str | None, Exception | None, Exception | None]
+    ]:
         yield ("missing", "1.0", None, None, ImportError("boom"), None)
         yield ("ok", "1.0", object(), "1.2", None, None)
 

--- a/tests/test_pipeline_logging_utils_module.py
+++ b/tests/test_pipeline_logging_utils_module.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import json
 import logging
 
-from diaremot.pipeline.logging_utils import CoreLogger, JSONLWriter, RunStats, StageGuard
+from diaremot.pipeline.logging_utils import (
+    CoreLogger,
+    JSONLWriter,
+    RunStats,
+    StageGuard,
+)
 
 
 def test_jsonl_writer_appends_records(tmp_path) -> None:

--- a/tests/test_run_pipeline_shim.py
+++ b/tests/test_run_pipeline_shim.py
@@ -63,12 +63,16 @@ def test_shim_delegates_functions(monkeypatch, shim):
     assert config == {"config": {"beam_size": 2}}
     assert calls["build"] == {"beam_size": 2}
 
-    result = module.run_pipeline("input.wav", "out", config={"beam": 3}, clear_cache=True)
+    result = module.run_pipeline(
+        "input.wav", "out", config={"beam": 3}, clear_cache=True
+    )
     assert result == {"status": "ok"}
     assert calls["run"] == ("input.wav", "out", {"beam": 3}, True)
 
     with pytest.warns(RuntimeWarning, match="allow_reprocess"):
-        resume_payload = module.resume("ckpt.json", outdir="out", config={"foo": 1}, allow_reprocess=True)
+        resume_payload = module.resume(
+            "ckpt.json", outdir="out", config={"foo": 1}, allow_reprocess=True
+        )
     assert resume_payload == {"resume": True}
     assert calls["resume"] == ("ckpt.json", "out", {"foo": 1})
 

--- a/tests/test_silero_wrapper.py
+++ b/tests/test_silero_wrapper.py
@@ -5,8 +5,12 @@ from unittest import mock
 
 import pytest
 
-np = pytest.importorskip("numpy")
-if getattr(np, "__stub__", False):
+try:
+    import numpy as np
+except ModuleNotFoundError:  # pragma: no cover - exercised only when numpy missing
+    pytest.skip("numpy is required for silero wrapper tests", allow_module_level=True)
+
+if getattr(np, "__stub__", False) or not hasattr(np, "ones"):
     pytest.skip("numpy not available", allow_module_level=True)
 
 
@@ -19,7 +23,9 @@ if str(SRC_ROOT) not in sys.path:
 if "librosa" not in sys.modules:
     librosa_stub = SimpleNamespace(
         util=SimpleNamespace(frame=lambda *args, **kwargs: np.zeros((0,))),
-        feature=SimpleNamespace(melspectrogram=lambda *args, **kwargs: np.zeros((1, 1))),
+        feature=SimpleNamespace(
+            melspectrogram=lambda *args, **kwargs: np.zeros((1, 1))
+        ),
         power_to_db=lambda x, ref=1.0: x,
     )
     sys.modules["librosa"] = librosa_stub
@@ -29,7 +35,7 @@ if "scipy" not in sys.modules:
     sys.modules["scipy"] = SimpleNamespace(signal=scipy_signal)
     sys.modules["scipy.signal"] = scipy_signal
 
-from diaremot.pipeline.speaker_diarization import _SileroWrapper
+from diaremot.pipeline.speaker_diarization import _SileroWrapper  # noqa: E402
 
 
 class _DummyTensor:

--- a/tests/test_speaker_registry.py
+++ b/tests/test_speaker_registry.py
@@ -7,9 +7,10 @@ from pathlib import Path
 
 import pytest
 
-np = pytest.importorskip("numpy")
-if getattr(np, "__stub__", False):
-    pytest.skip("numpy not available", allow_module_level=True)
+try:
+    import numpy as np
+except ModuleNotFoundError:  # pragma: no cover - exercised only when numpy missing
+    pytest.skip("numpy is required for speaker registry tests", allow_module_level=True)
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 SRC_ROOT = PROJECT_ROOT / "src"
@@ -40,9 +41,12 @@ def _install_test_stubs() -> None:
 
 _install_test_stubs()
 
-from diaremot.pipeline.speaker_diarization import SpeakerRegistry
+from diaremot.pipeline.speaker_diarization import SpeakerRegistry  # noqa: E402
 
-import diaremot
+import diaremot  # noqa: E402
+
+if getattr(np, "__stub__", False) or not hasattr(np, "zeros"):
+    pytest.skip("numpy not available", allow_module_level=True)
 
 
 class SpeakerRegistrySchemaTest(unittest.TestCase):
@@ -61,9 +65,13 @@ class SpeakerRegistrySchemaTest(unittest.TestCase):
             registry = SpeakerRegistry(str(path))
             self.assertTrue(registry.has("Alice"))
 
-            registry.update_centroid("Alice", np.asarray([0.2, 0.1, 0.3], dtype=np.float32))
+            registry.update_centroid(
+                "Alice", np.asarray([0.2, 0.1, 0.3], dtype=np.float32)
+            )
             registry.enroll("Bob", np.asarray([0.3, 0.4, 0.5], dtype=np.float32))
-            match_name, _ = registry.match(np.asarray([0.3, 0.4, 0.5], dtype=np.float32))
+            match_name, _ = registry.match(
+                np.asarray([0.3, 0.4, 0.5], dtype=np.float32)
+            )
             self.assertIn(match_name, {"Alice", "Bob"})
 
             registry.save()
@@ -96,9 +104,13 @@ class SpeakerRegistrySchemaTest(unittest.TestCase):
             registry = SpeakerRegistry(str(path))
             self.assertTrue(registry.has("Alice"))
 
-            registry.update_centroid("Alice", np.asarray([0.2, 0.1, 0.3], dtype=np.float32))
+            registry.update_centroid(
+                "Alice", np.asarray([0.2, 0.1, 0.3], dtype=np.float32)
+            )
             registry.enroll("Bob", np.asarray([0.3, 0.4, 0.5], dtype=np.float32))
-            _match_name, score = registry.match(np.asarray([0.2, 0.1, 0.3], dtype=np.float32))
+            _match_name, score = registry.match(
+                np.asarray([0.2, 0.1, 0.3], dtype=np.float32)
+            )
             self.assertGreaterEqual(score, 0.0)
 
             registry.save()

--- a/tests/test_stageguard.py
+++ b/tests/test_stageguard.py
@@ -8,9 +8,10 @@ import uuid
 
 import pytest
 
-np = pytest.importorskip("numpy")
-if getattr(np, "__stub__", False):
-    pytest.skip("numpy not available", allow_module_level=True)
+try:
+    import numpy as np
+except ModuleNotFoundError:  # pragma: no cover - exercised only when numpy missing
+    pytest.skip("numpy is required for stageguard tests", allow_module_level=True)
 
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -322,9 +323,12 @@ def _install_audio_pipeline_stubs() -> None:
 
 _install_audio_pipeline_stubs()
 
-from diaremot.pipeline.logging_utils import CoreLogger, RunStats, StageGuard
-from diaremot.pipeline.orchestrator import AudioAnalysisPipelineV2
-from diaremot.pipeline.outputs import default_affect
+from diaremot.pipeline.logging_utils import CoreLogger, RunStats, StageGuard  # noqa: E402
+from diaremot.pipeline.orchestrator import AudioAnalysisPipelineV2  # noqa: E402
+from diaremot.pipeline.outputs import default_affect  # noqa: E402
+
+if getattr(np, "__stub__", False) or not hasattr(np, "array"):
+    pytest.skip("numpy not available", allow_module_level=True)
 
 
 def _make_guard(tmp_path, stage: str):

--- a/tmp_check.py
+++ b/tmp_check.py
@@ -1,6 +1,7 @@
 from export_panns_onnx import _load_checkpoint, _Cnn14Wrapper
 import torch
-model = _load_checkpoint(__import__('pathlib').Path('models/panns/Cnn14_mAP=0.431.pth'))
+
+model = _load_checkpoint(__import__("pathlib").Path("models/panns/Cnn14_mAP=0.431.pth"))
 wrapped = _Cnn14Wrapper(model)
 wrapped.eval()
 with torch.no_grad():

--- a/tmp_inspect.py
+++ b/tmp_inspect.py
@@ -1,9 +1,17 @@
 import torch
 from panns_inference.models import Cnn14
 
-model = Cnn14(sample_rate=32000, window_size=1024, hop_size=320, mel_bins=64, fmin=50, fmax=14000, classes_num=527)
+model = Cnn14(
+    sample_rate=32000,
+    window_size=1024,
+    hop_size=320,
+    mel_bins=64,
+    fmin=50,
+    fmax=14000,
+    classes_num=527,
+)
 model.eval()
-dummy = torch.zeros(1, 32000*10)
+dummy = torch.zeros(1, 32000 * 10)
 with torch.no_grad():
     out = model(dummy)
 print(type(out))

--- a/tmp_models.py
+++ b/tmp_models.py
@@ -5,123 +5,143 @@ from torchlibrosa.stft import Spectrogram, LogmelFilterBank
 from torchlibrosa.augmentation import SpecAugmentation
 
 from pytorch_utils import do_mixup, interpolate, pad_framewise_output
- 
+
 
 def init_layer(layer):
-    """Initialize a Linear or Convolutional layer. """
+    """Initialize a Linear or Convolutional layer."""
     nn.init.xavier_uniform_(layer.weight)
- 
-    if hasattr(layer, 'bias'):
+
+    if hasattr(layer, "bias"):
         if layer.bias is not None:
-            layer.bias.data.fill_(0.)
-            
-    
+            layer.bias.data.fill_(0.0)
+
+
 def init_bn(bn):
-    """Initialize a Batchnorm layer. """
-    bn.bias.data.fill_(0.)
-    bn.weight.data.fill_(1.)
+    """Initialize a Batchnorm layer."""
+    bn.bias.data.fill_(0.0)
+    bn.weight.data.fill_(1.0)
 
 
 class ConvBlock(nn.Module):
     def __init__(self, in_channels, out_channels):
-        
         super(ConvBlock, self).__init__()
-        
-        self.conv1 = nn.Conv2d(in_channels=in_channels, 
-                              out_channels=out_channels,
-                              kernel_size=(3, 3), stride=(1, 1),
-                              padding=(1, 1), bias=False)
-                              
-        self.conv2 = nn.Conv2d(in_channels=out_channels, 
-                              out_channels=out_channels,
-                              kernel_size=(3, 3), stride=(1, 1),
-                              padding=(1, 1), bias=False)
-                              
+
+        self.conv1 = nn.Conv2d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=(3, 3),
+            stride=(1, 1),
+            padding=(1, 1),
+            bias=False,
+        )
+
+        self.conv2 = nn.Conv2d(
+            in_channels=out_channels,
+            out_channels=out_channels,
+            kernel_size=(3, 3),
+            stride=(1, 1),
+            padding=(1, 1),
+            bias=False,
+        )
+
         self.bn1 = nn.BatchNorm2d(out_channels)
         self.bn2 = nn.BatchNorm2d(out_channels)
 
         self.init_weight()
-        
+
     def init_weight(self):
         init_layer(self.conv1)
         init_layer(self.conv2)
         init_bn(self.bn1)
         init_bn(self.bn2)
 
-        
-    def forward(self, input, pool_size=(2, 2), pool_type='avg'):
-        
+    def forward(self, input, pool_size=(2, 2), pool_type="avg"):
         x = input
         x = F.relu_(self.bn1(self.conv1(x)))
         x = F.relu_(self.bn2(self.conv2(x)))
-        if pool_type == 'max':
+        if pool_type == "max":
             x = F.max_pool2d(x, kernel_size=pool_size)
-        elif pool_type == 'avg':
+        elif pool_type == "avg":
             x = F.avg_pool2d(x, kernel_size=pool_size)
-        elif pool_type == 'avg+max':
+        elif pool_type == "avg+max":
             x1 = F.avg_pool2d(x, kernel_size=pool_size)
             x2 = F.max_pool2d(x, kernel_size=pool_size)
             x = x1 + x2
         else:
-            raise Exception('Incorrect argument!')
-        
+            raise Exception("Incorrect argument!")
+
         return x
 
 
 class ConvBlock5x5(nn.Module):
     def __init__(self, in_channels, out_channels):
-        
         super(ConvBlock5x5, self).__init__()
-        
-        self.conv1 = nn.Conv2d(in_channels=in_channels, 
-                              out_channels=out_channels,
-                              kernel_size=(5, 5), stride=(1, 1),
-                              padding=(2, 2), bias=False)
-                              
+
+        self.conv1 = nn.Conv2d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=(5, 5),
+            stride=(1, 1),
+            padding=(2, 2),
+            bias=False,
+        )
+
         self.bn1 = nn.BatchNorm2d(out_channels)
 
         self.init_weight()
-        
+
     def init_weight(self):
         init_layer(self.conv1)
         init_bn(self.bn1)
 
-        
-    def forward(self, input, pool_size=(2, 2), pool_type='avg'):
-        
+    def forward(self, input, pool_size=(2, 2), pool_type="avg"):
         x = input
         x = F.relu_(self.bn1(self.conv1(x)))
-        if pool_type == 'max':
+        if pool_type == "max":
             x = F.max_pool2d(x, kernel_size=pool_size)
-        elif pool_type == 'avg':
+        elif pool_type == "avg":
             x = F.avg_pool2d(x, kernel_size=pool_size)
-        elif pool_type == 'avg+max':
+        elif pool_type == "avg+max":
             x1 = F.avg_pool2d(x, kernel_size=pool_size)
             x2 = F.max_pool2d(x, kernel_size=pool_size)
             x = x1 + x2
         else:
-            raise Exception('Incorrect argument!')
-        
+            raise Exception("Incorrect argument!")
+
         return x
 
 
 class AttBlock(nn.Module):
-    def __init__(self, n_in, n_out, activation='linear', temperature=1.):
+    def __init__(self, n_in, n_out, activation="linear", temperature=1.0):
         super(AttBlock, self).__init__()
-        
+
         self.activation = activation
         self.temperature = temperature
-        self.att = nn.Conv1d(in_channels=n_in, out_channels=n_out, kernel_size=1, stride=1, padding=0, bias=True)
-        self.cla = nn.Conv1d(in_channels=n_in, out_channels=n_out, kernel_size=1, stride=1, padding=0, bias=True)
-        
+        self.att = nn.Conv1d(
+            in_channels=n_in,
+            out_channels=n_out,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            bias=True,
+        )
+        self.cla = nn.Conv1d(
+            in_channels=n_in,
+            out_channels=n_out,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            bias=True,
+        )
+
         self.bn_att = nn.BatchNorm1d(n_out)
         self.init_weights()
-        
+
     def init_weights(self):
         init_layer(self.att)
         init_layer(self.cla)
         init_bn(self.bn_att)
-         
+
     def forward(self, x):
         # x: (n_samples, n_in, n_time)
         norm_att = torch.softmax(torch.clamp(self.att(x), -10, 10), dim=-1)
@@ -130,38 +150,56 @@ class AttBlock(nn.Module):
         return x, norm_att, cla
 
     def nonlinear_transform(self, x):
-        if self.activation == 'linear':
+        if self.activation == "linear":
             return x
-        elif self.activation == 'sigmoid':
+        elif self.activation == "sigmoid":
             return torch.sigmoid(x)
 
 
 class Cnn14(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(Cnn14, self).__init__()
 
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
         ref = 1.0
         amin = 1e-10
         top_db = None
 
         # Spectrogram extractor
-        self.spectrogram_extractor = Spectrogram(n_fft=window_size, hop_length=hop_size, 
-            win_length=window_size, window=window, center=center, pad_mode=pad_mode, 
-            freeze_parameters=True)
+        self.spectrogram_extractor = Spectrogram(
+            n_fft=window_size,
+            hop_length=hop_size,
+            win_length=window_size,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         # Logmel feature extractor
-        self.logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=window_size, 
-            n_mels=mel_bins, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db, 
-            freeze_parameters=True)
+        self.logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=window_size,
+            n_mels=mel_bins,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         # Spec augmenter
-        self.spec_augmenter = SpecAugmentation(time_drop_width=64, time_stripes_num=2, 
-            freq_drop_width=8, freq_stripes_num=2)
+        self.spec_augmenter = SpecAugmentation(
+            time_drop_width=64,
+            time_stripes_num=2,
+            freq_drop_width=8,
+            freq_stripes_num=2,
+        )
 
         self.bn0 = nn.BatchNorm2d(64)
 
@@ -174,25 +212,25 @@ class Cnn14(nn.Module):
 
         self.fc1 = nn.Linear(2048, 2048, bias=True)
         self.fc_audioset = nn.Linear(2048, classes_num, bias=True)
-        
+
         self.init_weight()
 
     def init_weight(self):
         init_bn(self.bn0)
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
 
-        x = self.spectrogram_extractor(input)   # (batch_size, 1, time_steps, freq_bins)
-        x = self.logmel_extractor(x)    # (batch_size, 1, time_steps, mel_bins)
+        x = self.spectrogram_extractor(input)  # (batch_size, 1, time_steps, freq_bins)
+        x = self.logmel_extractor(x)  # (batch_size, 1, time_steps, mel_bins)
 
         x = x.transpose(1, 3)
         x = self.bn0(x)
         x = x.transpose(1, 3)
-        
+
         if self.training:
             x = self.spec_augmenter(x)
 
@@ -200,20 +238,20 @@ class Cnn14(nn.Module):
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
 
-        x = self.conv_block1(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block1(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block2(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block2(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block3(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block3(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block4(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block4(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block5(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block5(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block6(x, pool_size=(1, 1), pool_type='avg')
+        x = self.conv_block6(x, pool_size=(1, 1), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
         x = torch.mean(x, dim=3)
-        
+
         (x1, _) = torch.max(x, dim=2)
         x2 = torch.mean(x, dim=2)
         x = x1 + x2
@@ -221,34 +259,48 @@ class Cnn14(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 class Cnn14_no_specaug(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(Cnn14_no_specaug, self).__init__()
 
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
         ref = 1.0
         amin = 1e-10
         top_db = None
 
         # Spectrogram extractor
-        self.spectrogram_extractor = Spectrogram(n_fft=window_size, hop_length=hop_size, 
-            win_length=window_size, window=window, center=center, pad_mode=pad_mode, 
-            freeze_parameters=True)
+        self.spectrogram_extractor = Spectrogram(
+            n_fft=window_size,
+            hop_length=hop_size,
+            win_length=window_size,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         # Logmel feature extractor
-        self.logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=window_size, 
-            n_mels=mel_bins, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db, 
-            freeze_parameters=True)
+        self.logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=window_size,
+            n_mels=mel_bins,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         self.bn0 = nn.BatchNorm2d(64)
 
@@ -261,43 +313,43 @@ class Cnn14_no_specaug(nn.Module):
 
         self.fc1 = nn.Linear(2048, 2048, bias=True)
         self.fc_audioset = nn.Linear(2048, classes_num, bias=True)
-        
+
         self.init_weight()
 
     def init_weight(self):
         init_bn(self.bn0)
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
 
-        x = self.spectrogram_extractor(input)   # (batch_size, 1, time_steps, freq_bins)
-        x = self.logmel_extractor(x)    # (batch_size, 1, time_steps, mel_bins)
-        
+        x = self.spectrogram_extractor(input)  # (batch_size, 1, time_steps, freq_bins)
+        x = self.logmel_extractor(x)  # (batch_size, 1, time_steps, mel_bins)
+
         x = x.transpose(1, 3)
         x = self.bn0(x)
         x = x.transpose(1, 3)
-        
+
         # Mixup on spectrogram
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
-        
-        x = self.conv_block1(x, pool_size=(2, 2), pool_type='avg')
+
+        x = self.conv_block1(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block2(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block2(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block3(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block3(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block4(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block4(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block5(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block5(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block6(x, pool_size=(1, 1), pool_type='avg')
+        x = self.conv_block6(x, pool_size=(1, 1), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
         x = torch.mean(x, dim=3)
-        
+
         (x1, _) = torch.max(x, dim=2)
         x2 = torch.mean(x, dim=2)
         x = x1 + x2
@@ -305,38 +357,56 @@ class Cnn14_no_specaug(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 class Cnn14_no_dropout(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(Cnn14_no_dropout, self).__init__()
 
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
         ref = 1.0
         amin = 1e-10
         top_db = None
 
         # Spectrogram extractor
-        self.spectrogram_extractor = Spectrogram(n_fft=window_size, hop_length=hop_size, 
-            win_length=window_size, window=window, center=center, pad_mode=pad_mode, 
-            freeze_parameters=True)
+        self.spectrogram_extractor = Spectrogram(
+            n_fft=window_size,
+            hop_length=hop_size,
+            win_length=window_size,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         # Logmel feature extractor
-        self.logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=window_size, 
-            n_mels=mel_bins, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db, 
-            freeze_parameters=True)
+        self.logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=window_size,
+            n_mels=mel_bins,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         # Spec augmenter
-        self.spec_augmenter = SpecAugmentation(time_drop_width=64, time_stripes_num=2, 
-            freq_drop_width=8, freq_stripes_num=2)
+        self.spec_augmenter = SpecAugmentation(
+            time_drop_width=64,
+            time_stripes_num=2,
+            freq_drop_width=8,
+            freq_stripes_num=2,
+        )
 
         self.bn0 = nn.BatchNorm2d(64)
 
@@ -349,40 +419,40 @@ class Cnn14_no_dropout(nn.Module):
 
         self.fc1 = nn.Linear(2048, 2048, bias=True)
         self.fc_audioset = nn.Linear(2048, classes_num, bias=True)
-        
+
         self.init_weight()
 
     def init_weight(self):
         init_bn(self.bn0)
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
 
-        x = self.spectrogram_extractor(input)   # (batch_size, 1, time_steps, freq_bins)
-        x = self.logmel_extractor(x)    # (batch_size, 1, time_steps, mel_bins)
-        
+        x = self.spectrogram_extractor(input)  # (batch_size, 1, time_steps, freq_bins)
+        x = self.logmel_extractor(x)  # (batch_size, 1, time_steps, mel_bins)
+
         x = x.transpose(1, 3)
         x = self.bn0(x)
         x = x.transpose(1, 3)
-        
+
         if self.training:
             x = self.spec_augmenter(x)
 
         # Mixup on spectrogram
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
-        
-        x = self.conv_block1(x, pool_size=(2, 2), pool_type='avg')
-        x = self.conv_block2(x, pool_size=(2, 2), pool_type='avg')
-        x = self.conv_block3(x, pool_size=(2, 2), pool_type='avg')
-        x = self.conv_block4(x, pool_size=(2, 2), pool_type='avg')
-        x = self.conv_block5(x, pool_size=(2, 2), pool_type='avg')
-        x = self.conv_block6(x, pool_size=(1, 1), pool_type='avg')
+
+        x = self.conv_block1(x, pool_size=(2, 2), pool_type="avg")
+        x = self.conv_block2(x, pool_size=(2, 2), pool_type="avg")
+        x = self.conv_block3(x, pool_size=(2, 2), pool_type="avg")
+        x = self.conv_block4(x, pool_size=(2, 2), pool_type="avg")
+        x = self.conv_block5(x, pool_size=(2, 2), pool_type="avg")
+        x = self.conv_block6(x, pool_size=(1, 1), pool_type="avg")
         x = torch.mean(x, dim=3)
-        
+
         (x1, _) = torch.max(x, dim=2)
         x2 = torch.mean(x, dim=2)
         x = x1 + x2
@@ -390,38 +460,56 @@ class Cnn14_no_dropout(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 class Cnn6(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(Cnn6, self).__init__()
 
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
         ref = 1.0
         amin = 1e-10
         top_db = None
 
         # Spectrogram extractor
-        self.spectrogram_extractor = Spectrogram(n_fft=window_size, hop_length=hop_size, 
-            win_length=window_size, window=window, center=center, pad_mode=pad_mode, 
-            freeze_parameters=True)
+        self.spectrogram_extractor = Spectrogram(
+            n_fft=window_size,
+            hop_length=hop_size,
+            win_length=window_size,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         # Logmel feature extractor
-        self.logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=window_size, 
-            n_mels=mel_bins, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db, 
-            freeze_parameters=True)
+        self.logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=window_size,
+            n_mels=mel_bins,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         # Spec augmenter
-        self.spec_augmenter = SpecAugmentation(time_drop_width=64, time_stripes_num=2, 
-            freq_drop_width=8, freq_stripes_num=2)
+        self.spec_augmenter = SpecAugmentation(
+            time_drop_width=64,
+            time_stripes_num=2,
+            freq_drop_width=8,
+            freq_stripes_num=2,
+        )
 
         self.bn0 = nn.BatchNorm2d(64)
 
@@ -432,42 +520,42 @@ class Cnn6(nn.Module):
 
         self.fc1 = nn.Linear(512, 512, bias=True)
         self.fc_audioset = nn.Linear(512, classes_num, bias=True)
-        
+
         self.init_weight()
 
     def init_weight(self):
         init_bn(self.bn0)
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
 
-        x = self.spectrogram_extractor(input)   # (batch_size, 1, time_steps, freq_bins)
-        x = self.logmel_extractor(x)    # (batch_size, 1, time_steps, mel_bins)
-        
+        x = self.spectrogram_extractor(input)  # (batch_size, 1, time_steps, freq_bins)
+        x = self.logmel_extractor(x)  # (batch_size, 1, time_steps, mel_bins)
+
         x = x.transpose(1, 3)
         x = self.bn0(x)
         x = x.transpose(1, 3)
-        
+
         if self.training:
             x = self.spec_augmenter(x)
 
         # Mixup on spectrogram
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
-        
-        x = self.conv_block1(x, pool_size=(2, 2), pool_type='avg')
+
+        x = self.conv_block1(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block2(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block2(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block3(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block3(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block4(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block4(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
         x = torch.mean(x, dim=3)
-        
+
         (x1, _) = torch.max(x, dim=2)
         x2 = torch.mean(x, dim=2)
         x = x1 + x2
@@ -475,38 +563,56 @@ class Cnn6(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 class Cnn10(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(Cnn10, self).__init__()
 
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
         ref = 1.0
         amin = 1e-10
         top_db = None
 
         # Spectrogram extractor
-        self.spectrogram_extractor = Spectrogram(n_fft=window_size, hop_length=hop_size, 
-            win_length=window_size, window=window, center=center, pad_mode=pad_mode, 
-            freeze_parameters=True)
+        self.spectrogram_extractor = Spectrogram(
+            n_fft=window_size,
+            hop_length=hop_size,
+            win_length=window_size,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         # Logmel feature extractor
-        self.logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=window_size, 
-            n_mels=mel_bins, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db, 
-            freeze_parameters=True)
+        self.logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=window_size,
+            n_mels=mel_bins,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         # Spec augmenter
-        self.spec_augmenter = SpecAugmentation(time_drop_width=64, time_stripes_num=2, 
-            freq_drop_width=8, freq_stripes_num=2)
+        self.spec_augmenter = SpecAugmentation(
+            time_drop_width=64,
+            time_stripes_num=2,
+            freq_drop_width=8,
+            freq_stripes_num=2,
+        )
 
         self.bn0 = nn.BatchNorm2d(64)
 
@@ -517,42 +623,42 @@ class Cnn10(nn.Module):
 
         self.fc1 = nn.Linear(512, 512, bias=True)
         self.fc_audioset = nn.Linear(512, classes_num, bias=True)
-        
+
         self.init_weight()
 
     def init_weight(self):
         init_bn(self.bn0)
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
 
-        x = self.spectrogram_extractor(input)   # (batch_size, 1, time_steps, freq_bins)
-        x = self.logmel_extractor(x)    # (batch_size, 1, time_steps, mel_bins)
-        
+        x = self.spectrogram_extractor(input)  # (batch_size, 1, time_steps, freq_bins)
+        x = self.logmel_extractor(x)  # (batch_size, 1, time_steps, mel_bins)
+
         x = x.transpose(1, 3)
         x = self.bn0(x)
         x = x.transpose(1, 3)
-        
+
         if self.training:
             x = self.spec_augmenter(x)
 
         # Mixup on spectrogram
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
-        
-        x = self.conv_block1(x, pool_size=(2, 2), pool_type='avg')
+
+        x = self.conv_block1(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block2(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block2(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block3(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block3(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block4(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block4(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
         x = torch.mean(x, dim=3)
-        
+
         (x1, _) = torch.max(x, dim=2)
         x2 = torch.mean(x, dim=2)
         x = x1 + x2
@@ -560,33 +666,52 @@ class Cnn10(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 def _resnet_conv3x3(in_planes, out_planes):
-    #3x3 convolution with padding
-    return nn.Conv2d(in_planes, out_planes, kernel_size=3, stride=1,
-                     padding=1, groups=1, bias=False, dilation=1)
+    # 3x3 convolution with padding
+    return nn.Conv2d(
+        in_planes,
+        out_planes,
+        kernel_size=3,
+        stride=1,
+        padding=1,
+        groups=1,
+        bias=False,
+        dilation=1,
+    )
 
 
 def _resnet_conv1x1(in_planes, out_planes):
-    #1x1 convolution
+    # 1x1 convolution
     return nn.Conv2d(in_planes, out_planes, kernel_size=1, stride=1, bias=False)
 
 
 class _ResnetBasicBlock(nn.Module):
     expansion = 1
 
-    def __init__(self, inplanes, planes, stride=1, downsample=None, groups=1,
-                 base_width=64, dilation=1, norm_layer=None):
+    def __init__(
+        self,
+        inplanes,
+        planes,
+        stride=1,
+        downsample=None,
+        groups=1,
+        base_width=64,
+        dilation=1,
+        norm_layer=None,
+    ):
         super(_ResnetBasicBlock, self).__init__()
         if norm_layer is None:
             norm_layer = nn.BatchNorm2d
         if groups != 1 or base_width != 64:
-            raise ValueError('_ResnetBasicBlock only supports groups=1 and base_width=64')
+            raise ValueError(
+                "_ResnetBasicBlock only supports groups=1 and base_width=64"
+            )
         if dilation > 1:
             raise NotImplementedError("Dilation > 1 not supported in _ResnetBasicBlock")
         # Both self.conv1 and self.downsample layers downsample the input when stride != 1
@@ -625,7 +750,7 @@ class _ResnetBasicBlock(nn.Module):
 
         out = self.conv2(out)
         out = self.bn2(out)
-        
+
         if self.downsample is not None:
             identity = self.downsample(identity)
 
@@ -638,12 +763,21 @@ class _ResnetBasicBlock(nn.Module):
 class _ResnetBottleneck(nn.Module):
     expansion = 4
 
-    def __init__(self, inplanes, planes, stride=1, downsample=None, groups=1,
-                 base_width=64, dilation=1, norm_layer=None):
+    def __init__(
+        self,
+        inplanes,
+        planes,
+        stride=1,
+        downsample=None,
+        groups=1,
+        base_width=64,
+        dilation=1,
+        norm_layer=None,
+    ):
         super(_ResnetBottleneck, self).__init__()
         if norm_layer is None:
             norm_layer = nn.BatchNorm2d
-        width = int(planes * (base_width / 64.)) * groups
+        width = int(planes * (base_width / 64.0)) * groups
         self.stride = stride
         # Both self.conv2 and self.downsample layers downsample the input when stride != 1
         self.conv1 = _resnet_conv1x1(inplanes, width)
@@ -695,9 +829,16 @@ class _ResnetBottleneck(nn.Module):
 
 
 class _ResNet(nn.Module):
-    def __init__(self, block, layers, zero_init_residual=False,
-                 groups=1, width_per_group=64, replace_stride_with_dilation=None,
-                 norm_layer=None):
+    def __init__(
+        self,
+        block,
+        layers,
+        zero_init_residual=False,
+        groups=1,
+        width_per_group=64,
+        replace_stride_with_dilation=None,
+        norm_layer=None,
+    ):
         super(_ResNet, self).__init__()
 
         if norm_layer is None:
@@ -711,18 +852,23 @@ class _ResNet(nn.Module):
             # the 2x2 stride with a dilated convolution instead
             replace_stride_with_dilation = [False, False, False]
         if len(replace_stride_with_dilation) != 3:
-            raise ValueError("replace_stride_with_dilation should be None "
-                             "or a 3-element tuple, got {}".format(replace_stride_with_dilation))
+            raise ValueError(
+                "replace_stride_with_dilation should be None "
+                "or a 3-element tuple, got {}".format(replace_stride_with_dilation)
+            )
         self.groups = groups
         self.base_width = width_per_group
 
         self.layer1 = self._make_layer(block, 64, layers[0], stride=1)
-        self.layer2 = self._make_layer(block, 128, layers[1], stride=2,
-                                       dilate=replace_stride_with_dilation[0])
-        self.layer3 = self._make_layer(block, 256, layers[2], stride=2,
-                                       dilate=replace_stride_with_dilation[1])
-        self.layer4 = self._make_layer(block, 512, layers[3], stride=2,
-                                       dilate=replace_stride_with_dilation[2])
+        self.layer2 = self._make_layer(
+            block, 128, layers[1], stride=2, dilate=replace_stride_with_dilation[0]
+        )
+        self.layer3 = self._make_layer(
+            block, 256, layers[2], stride=2, dilate=replace_stride_with_dilation[1]
+        )
+        self.layer4 = self._make_layer(
+            block, 512, layers[3], stride=2, dilate=replace_stride_with_dilation[2]
+        )
 
     def _make_layer(self, block, planes, blocks, stride=1, dilate=False):
         norm_layer = self._norm_layer
@@ -741,7 +887,7 @@ class _ResNet(nn.Module):
                 init_bn(downsample[1])
             elif stride == 2:
                 downsample = nn.Sequential(
-                    nn.AvgPool2d(kernel_size=2), 
+                    nn.AvgPool2d(kernel_size=2),
                     _resnet_conv1x1(self.inplanes, planes * block.expansion),
                     norm_layer(planes * block.expansion),
                 )
@@ -749,13 +895,30 @@ class _ResNet(nn.Module):
                 init_bn(downsample[2])
 
         layers = []
-        layers.append(block(self.inplanes, planes, stride, downsample, self.groups,
-                            self.base_width, previous_dilation, norm_layer))
+        layers.append(
+            block(
+                self.inplanes,
+                planes,
+                stride,
+                downsample,
+                self.groups,
+                self.base_width,
+                previous_dilation,
+                norm_layer,
+            )
+        )
         self.inplanes = planes * block.expansion
         for _ in range(1, blocks):
-            layers.append(block(self.inplanes, planes, groups=self.groups,
-                                base_width=self.base_width, dilation=self.dilation,
-                                norm_layer=norm_layer))
+            layers.append(
+                block(
+                    self.inplanes,
+                    planes,
+                    groups=self.groups,
+                    base_width=self.base_width,
+                    dilation=self.dilation,
+                    norm_layer=norm_layer,
+                )
+            )
 
         return nn.Sequential(*layers)
 
@@ -769,38 +932,58 @@ class _ResNet(nn.Module):
 
 
 class ResNet22(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(ResNet22, self).__init__()
 
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
         ref = 1.0
         amin = 1e-10
         top_db = None
 
         # Spectrogram extractor
-        self.spectrogram_extractor = Spectrogram(n_fft=window_size, hop_length=hop_size, 
-            win_length=window_size, window=window, center=center, pad_mode=pad_mode, 
-            freeze_parameters=True)
+        self.spectrogram_extractor = Spectrogram(
+            n_fft=window_size,
+            hop_length=hop_size,
+            win_length=window_size,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         # Logmel feature extractor
-        self.logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=window_size, 
-            n_mels=mel_bins, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db, 
-            freeze_parameters=True)
+        self.logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=window_size,
+            n_mels=mel_bins,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         # Spec augmenter
-        self.spec_augmenter = SpecAugmentation(time_drop_width=64, time_stripes_num=2, 
-            freq_drop_width=8, freq_stripes_num=2)
+        self.spec_augmenter = SpecAugmentation(
+            time_drop_width=64,
+            time_stripes_num=2,
+            freq_drop_width=8,
+            freq_stripes_num=2,
+        )
 
         self.bn0 = nn.BatchNorm2d(64)
 
         self.conv_block1 = ConvBlock(in_channels=1, out_channels=64)
         # self.conv_block2 = ConvBlock(in_channels=64, out_channels=64)
 
-        self.resnet = _ResNet(block=_ResnetBasicBlock, layers=[2, 2, 2, 2], zero_init_residual=True)
+        self.resnet = _ResNet(
+            block=_ResnetBasicBlock, layers=[2, 2, 2, 2], zero_init_residual=True
+        )
 
         self.conv_block_after1 = ConvBlock(in_channels=512, out_channels=2048)
 
@@ -814,34 +997,33 @@ class ResNet22(nn.Module):
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
 
-
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
 
-        x = self.spectrogram_extractor(input)   # (batch_size, 1, time_steps, freq_bins)
-        x = self.logmel_extractor(x)    # (batch_size, 1, time_steps, mel_bins)
-        
+        x = self.spectrogram_extractor(input)  # (batch_size, 1, time_steps, freq_bins)
+        x = self.logmel_extractor(x)  # (batch_size, 1, time_steps, mel_bins)
+
         x = x.transpose(1, 3)
         x = self.bn0(x)
         x = x.transpose(1, 3)
-        
+
         if self.training:
             x = self.spec_augmenter(x)
 
         # Mixup on spectrogram
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
-        
-        x = self.conv_block1(x, pool_size=(2, 2), pool_type='avg')
+
+        x = self.conv_block1(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training, inplace=True)
         x = self.resnet(x)
         x = F.avg_pool2d(x, kernel_size=(2, 2))
         x = F.dropout(x, p=0.2, training=self.training, inplace=True)
-        x = self.conv_block_after1(x, pool_size=(1, 1), pool_type='avg')
+        x = self.conv_block_after1(x, pool_size=(1, 1), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training, inplace=True)
         x = torch.mean(x, dim=3)
-        
+
         (x1, _) = torch.max(x, dim=2)
         x2 = torch.mean(x, dim=2)
         x = x1 + x2
@@ -849,45 +1031,65 @@ class ResNet22(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 class ResNet38(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(ResNet38, self).__init__()
 
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
         ref = 1.0
         amin = 1e-10
         top_db = None
 
         # Spectrogram extractor
-        self.spectrogram_extractor = Spectrogram(n_fft=window_size, hop_length=hop_size, 
-            win_length=window_size, window=window, center=center, pad_mode=pad_mode, 
-            freeze_parameters=True)
+        self.spectrogram_extractor = Spectrogram(
+            n_fft=window_size,
+            hop_length=hop_size,
+            win_length=window_size,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         # Logmel feature extractor
-        self.logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=window_size, 
-            n_mels=mel_bins, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db, 
-            freeze_parameters=True)
+        self.logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=window_size,
+            n_mels=mel_bins,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         # Spec augmenter
-        self.spec_augmenter = SpecAugmentation(time_drop_width=64, time_stripes_num=2, 
-            freq_drop_width=8, freq_stripes_num=2)
+        self.spec_augmenter = SpecAugmentation(
+            time_drop_width=64,
+            time_stripes_num=2,
+            freq_drop_width=8,
+            freq_stripes_num=2,
+        )
 
         self.bn0 = nn.BatchNorm2d(64)
 
         self.conv_block1 = ConvBlock(in_channels=1, out_channels=64)
         # self.conv_block2 = ConvBlock(in_channels=64, out_channels=64)
 
-        self.resnet = _ResNet(block=_ResnetBasicBlock, layers=[3, 4, 6, 3], zero_init_residual=True)
+        self.resnet = _ResNet(
+            block=_ResnetBasicBlock, layers=[3, 4, 6, 3], zero_init_residual=True
+        )
 
         self.conv_block_after1 = ConvBlock(in_channels=512, out_channels=2048)
 
@@ -901,34 +1103,33 @@ class ResNet38(nn.Module):
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
 
-
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
 
-        x = self.spectrogram_extractor(input)   # (batch_size, 1, time_steps, freq_bins)
-        x = self.logmel_extractor(x)    # (batch_size, 1, time_steps, mel_bins)
-        
+        x = self.spectrogram_extractor(input)  # (batch_size, 1, time_steps, freq_bins)
+        x = self.logmel_extractor(x)  # (batch_size, 1, time_steps, mel_bins)
+
         x = x.transpose(1, 3)
         x = self.bn0(x)
         x = x.transpose(1, 3)
-        
+
         if self.training:
             x = self.spec_augmenter(x)
 
         # Mixup on spectrogram
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
-        
-        x = self.conv_block1(x, pool_size=(2, 2), pool_type='avg')
+
+        x = self.conv_block1(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training, inplace=True)
         x = self.resnet(x)
         x = F.avg_pool2d(x, kernel_size=(2, 2))
         x = F.dropout(x, p=0.2, training=self.training, inplace=True)
-        x = self.conv_block_after1(x, pool_size=(1, 1), pool_type='avg')
+        x = self.conv_block_after1(x, pool_size=(1, 1), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training, inplace=True)
         x = torch.mean(x, dim=3)
-        
+
         (x1, _) = torch.max(x, dim=2)
         x2 = torch.mean(x, dim=2)
         x = x1 + x2
@@ -936,45 +1137,65 @@ class ResNet38(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 class ResNet54(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(ResNet54, self).__init__()
 
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
         ref = 1.0
         amin = 1e-10
         top_db = None
 
         # Spectrogram extractor
-        self.spectrogram_extractor = Spectrogram(n_fft=window_size, hop_length=hop_size, 
-            win_length=window_size, window=window, center=center, pad_mode=pad_mode, 
-            freeze_parameters=True)
+        self.spectrogram_extractor = Spectrogram(
+            n_fft=window_size,
+            hop_length=hop_size,
+            win_length=window_size,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         # Logmel feature extractor
-        self.logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=window_size, 
-            n_mels=mel_bins, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db, 
-            freeze_parameters=True)
+        self.logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=window_size,
+            n_mels=mel_bins,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         # Spec augmenter
-        self.spec_augmenter = SpecAugmentation(time_drop_width=64, time_stripes_num=2, 
-            freq_drop_width=8, freq_stripes_num=2)
+        self.spec_augmenter = SpecAugmentation(
+            time_drop_width=64,
+            time_stripes_num=2,
+            freq_drop_width=8,
+            freq_stripes_num=2,
+        )
 
         self.bn0 = nn.BatchNorm2d(64)
 
         self.conv_block1 = ConvBlock(in_channels=1, out_channels=64)
         # self.conv_block2 = ConvBlock(in_channels=64, out_channels=64)
 
-        self.resnet = _ResNet(block=_ResnetBottleneck, layers=[3, 4, 6, 3], zero_init_residual=True)
+        self.resnet = _ResNet(
+            block=_ResnetBottleneck, layers=[3, 4, 6, 3], zero_init_residual=True
+        )
 
         self.conv_block_after1 = ConvBlock(in_channels=2048, out_channels=2048)
 
@@ -988,34 +1209,33 @@ class ResNet54(nn.Module):
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
 
-
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
 
-        x = self.spectrogram_extractor(input)   # (batch_size, 1, time_steps, freq_bins)
-        x = self.logmel_extractor(x)    # (batch_size, 1, time_steps, mel_bins)
-        
+        x = self.spectrogram_extractor(input)  # (batch_size, 1, time_steps, freq_bins)
+        x = self.logmel_extractor(x)  # (batch_size, 1, time_steps, mel_bins)
+
         x = x.transpose(1, 3)
         x = self.bn0(x)
         x = x.transpose(1, 3)
-        
+
         if self.training:
             x = self.spec_augmenter(x)
 
         # Mixup on spectrogram
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
-        
-        x = self.conv_block1(x, pool_size=(2, 2), pool_type='avg')
+
+        x = self.conv_block1(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training, inplace=True)
         x = self.resnet(x)
         x = F.avg_pool2d(x, kernel_size=(2, 2))
         x = F.dropout(x, p=0.2, training=self.training, inplace=True)
-        x = self.conv_block_after1(x, pool_size=(1, 1), pool_type='avg')
+        x = self.conv_block_after1(x, pool_size=(1, 1), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training, inplace=True)
         x = torch.mean(x, dim=3)
-        
+
         (x1, _) = torch.max(x, dim=2)
         x2 = torch.mean(x, dim=2)
         x = x1 + x2
@@ -1023,38 +1243,56 @@ class ResNet54(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 class Cnn14_emb512(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(Cnn14_emb512, self).__init__()
 
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
         ref = 1.0
         amin = 1e-10
         top_db = None
 
         # Spectrogram extractor
-        self.spectrogram_extractor = Spectrogram(n_fft=window_size, hop_length=hop_size, 
-            win_length=window_size, window=window, center=center, pad_mode=pad_mode, 
-            freeze_parameters=True)
+        self.spectrogram_extractor = Spectrogram(
+            n_fft=window_size,
+            hop_length=hop_size,
+            win_length=window_size,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         # Logmel feature extractor
-        self.logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=window_size, 
-            n_mels=mel_bins, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db, 
-            freeze_parameters=True)
+        self.logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=window_size,
+            n_mels=mel_bins,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         # Spec augmenter
-        self.spec_augmenter = SpecAugmentation(time_drop_width=64, time_stripes_num=2, 
-            freq_drop_width=8, freq_stripes_num=2)
+        self.spec_augmenter = SpecAugmentation(
+            time_drop_width=64,
+            time_stripes_num=2,
+            freq_drop_width=8,
+            freq_stripes_num=2,
+        )
 
         self.bn0 = nn.BatchNorm2d(64)
 
@@ -1067,46 +1305,46 @@ class Cnn14_emb512(nn.Module):
 
         self.fc1 = nn.Linear(2048, 512, bias=True)
         self.fc_audioset = nn.Linear(512, classes_num, bias=True)
-        
+
         self.init_weight()
 
     def init_weight(self):
         init_bn(self.bn0)
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
 
-        x = self.spectrogram_extractor(input)   # (batch_size, 1, time_steps, freq_bins)
-        x = self.logmel_extractor(x)    # (batch_size, 1, time_steps, mel_bins)
-        
+        x = self.spectrogram_extractor(input)  # (batch_size, 1, time_steps, freq_bins)
+        x = self.logmel_extractor(x)  # (batch_size, 1, time_steps, mel_bins)
+
         x = x.transpose(1, 3)
         x = self.bn0(x)
         x = x.transpose(1, 3)
-        
+
         if self.training:
             x = self.spec_augmenter(x)
 
         # Mixup on spectrogram
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
-        
-        x = self.conv_block1(x, pool_size=(2, 2), pool_type='avg')
+
+        x = self.conv_block1(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block2(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block2(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block3(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block3(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block4(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block4(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block5(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block5(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block6(x, pool_size=(1, 1), pool_type='avg')
+        x = self.conv_block6(x, pool_size=(1, 1), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
         x = torch.mean(x, dim=3)
-        
+
         (x1, _) = torch.max(x, dim=2)
         x2 = torch.mean(x, dim=2)
         x = x1 + x2
@@ -1114,38 +1352,56 @@ class Cnn14_emb512(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 class Cnn14_emb128(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(Cnn14_emb128, self).__init__()
 
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
         ref = 1.0
         amin = 1e-10
         top_db = None
 
         # Spectrogram extractor
-        self.spectrogram_extractor = Spectrogram(n_fft=window_size, hop_length=hop_size, 
-            win_length=window_size, window=window, center=center, pad_mode=pad_mode, 
-            freeze_parameters=True)
+        self.spectrogram_extractor = Spectrogram(
+            n_fft=window_size,
+            hop_length=hop_size,
+            win_length=window_size,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         # Logmel feature extractor
-        self.logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=window_size, 
-            n_mels=mel_bins, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db, 
-            freeze_parameters=True)
+        self.logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=window_size,
+            n_mels=mel_bins,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         # Spec augmenter
-        self.spec_augmenter = SpecAugmentation(time_drop_width=64, time_stripes_num=2, 
-            freq_drop_width=8, freq_stripes_num=2)
+        self.spec_augmenter = SpecAugmentation(
+            time_drop_width=64,
+            time_stripes_num=2,
+            freq_drop_width=8,
+            freq_stripes_num=2,
+        )
 
         self.bn0 = nn.BatchNorm2d(64)
 
@@ -1158,46 +1414,46 @@ class Cnn14_emb128(nn.Module):
 
         self.fc1 = nn.Linear(2048, 128, bias=True)
         self.fc_audioset = nn.Linear(128, classes_num, bias=True)
-        
+
         self.init_weight()
 
     def init_weight(self):
         init_bn(self.bn0)
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
 
-        x = self.spectrogram_extractor(input)   # (batch_size, 1, time_steps, freq_bins)
-        x = self.logmel_extractor(x)    # (batch_size, 1, time_steps, mel_bins)
-        
+        x = self.spectrogram_extractor(input)  # (batch_size, 1, time_steps, freq_bins)
+        x = self.logmel_extractor(x)  # (batch_size, 1, time_steps, mel_bins)
+
         x = x.transpose(1, 3)
         x = self.bn0(x)
         x = x.transpose(1, 3)
-        
+
         if self.training:
             x = self.spec_augmenter(x)
 
         # Mixup on spectrogram
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
-        
-        x = self.conv_block1(x, pool_size=(2, 2), pool_type='avg')
+
+        x = self.conv_block1(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block2(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block2(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block3(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block3(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block4(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block4(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block5(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block5(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block6(x, pool_size=(1, 1), pool_type='avg')
+        x = self.conv_block6(x, pool_size=(1, 1), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
         x = torch.mean(x, dim=3)
-        
+
         (x1, _) = torch.max(x, dim=2)
         x2 = torch.mean(x, dim=2)
         x = x1 + x2
@@ -1205,38 +1461,56 @@ class Cnn14_emb128(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 class Cnn14_emb32(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(Cnn14_emb32, self).__init__()
 
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
         ref = 1.0
         amin = 1e-10
         top_db = None
 
         # Spectrogram extractor
-        self.spectrogram_extractor = Spectrogram(n_fft=window_size, hop_length=hop_size, 
-            win_length=window_size, window=window, center=center, pad_mode=pad_mode, 
-            freeze_parameters=True)
+        self.spectrogram_extractor = Spectrogram(
+            n_fft=window_size,
+            hop_length=hop_size,
+            win_length=window_size,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         # Logmel feature extractor
-        self.logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=window_size, 
-            n_mels=mel_bins, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db, 
-            freeze_parameters=True)
+        self.logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=window_size,
+            n_mels=mel_bins,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         # Spec augmenter
-        self.spec_augmenter = SpecAugmentation(time_drop_width=64, time_stripes_num=2, 
-            freq_drop_width=8, freq_stripes_num=2)
+        self.spec_augmenter = SpecAugmentation(
+            time_drop_width=64,
+            time_stripes_num=2,
+            freq_drop_width=8,
+            freq_stripes_num=2,
+        )
 
         self.bn0 = nn.BatchNorm2d(64)
 
@@ -1249,46 +1523,46 @@ class Cnn14_emb32(nn.Module):
 
         self.fc1 = nn.Linear(2048, 32, bias=True)
         self.fc_audioset = nn.Linear(32, classes_num, bias=True)
-        
+
         self.init_weight()
 
     def init_weight(self):
         init_bn(self.bn0)
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
 
-        x = self.spectrogram_extractor(input)   # (batch_size, 1, time_steps, freq_bins)
-        x = self.logmel_extractor(x)    # (batch_size, 1, time_steps, mel_bins)
-        
+        x = self.spectrogram_extractor(input)  # (batch_size, 1, time_steps, freq_bins)
+        x = self.logmel_extractor(x)  # (batch_size, 1, time_steps, mel_bins)
+
         x = x.transpose(1, 3)
         x = self.bn0(x)
         x = x.transpose(1, 3)
-        
+
         if self.training:
             x = self.spec_augmenter(x)
 
         # Mixup on spectrogram
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
-        
-        x = self.conv_block1(x, pool_size=(2, 2), pool_type='avg')
+
+        x = self.conv_block1(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block2(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block2(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block3(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block3(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block4(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block4(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block5(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block5(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block6(x, pool_size=(1, 1), pool_type='avg')
+        x = self.conv_block6(x, pool_size=(1, 1), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
         x = torch.mean(x, dim=3)
-        
+
         (x1, _) = torch.max(x, dim=2)
         x2 = torch.mean(x, dim=2)
         x = x1 + x2
@@ -1296,48 +1570,66 @@ class Cnn14_emb32(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 class MobileNetV1(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(MobileNetV1, self).__init__()
 
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
         ref = 1.0
         amin = 1e-10
         top_db = None
 
         # Spectrogram extractor
-        self.spectrogram_extractor = Spectrogram(n_fft=window_size, hop_length=hop_size, 
-            win_length=window_size, window=window, center=center, pad_mode=pad_mode, 
-            freeze_parameters=True)
+        self.spectrogram_extractor = Spectrogram(
+            n_fft=window_size,
+            hop_length=hop_size,
+            win_length=window_size,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         # Logmel feature extractor
-        self.logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=window_size, 
-            n_mels=mel_bins, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db, 
-            freeze_parameters=True)
+        self.logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=window_size,
+            n_mels=mel_bins,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         # Spec augmenter
-        self.spec_augmenter = SpecAugmentation(time_drop_width=64, time_stripes_num=2, 
-            freq_drop_width=8, freq_stripes_num=2)
+        self.spec_augmenter = SpecAugmentation(
+            time_drop_width=64,
+            time_stripes_num=2,
+            freq_drop_width=8,
+            freq_stripes_num=2,
+        )
 
         self.bn0 = nn.BatchNorm2d(64)
 
         def conv_bn(inp, oup, stride):
             _layers = [
-                nn.Conv2d(inp, oup, 3, 1, 1, bias=False), 
-                nn.AvgPool2d(stride), 
-                nn.BatchNorm2d(oup), 
-                nn.ReLU(inplace=True)
-                ]
+                nn.Conv2d(inp, oup, 3, 1, 1, bias=False),
+                nn.AvgPool2d(stride),
+                nn.BatchNorm2d(oup),
+                nn.ReLU(inplace=True),
+            ]
             _layers = nn.Sequential(*_layers)
             init_layer(_layers[0])
             init_bn(_layers[2])
@@ -1345,14 +1637,14 @@ class MobileNetV1(nn.Module):
 
         def conv_dw(inp, oup, stride):
             _layers = [
-                nn.Conv2d(inp, inp, 3, 1, 1, groups=inp, bias=False), 
-                nn.AvgPool2d(stride), 
-                nn.BatchNorm2d(inp), 
-                nn.ReLU(inplace=True), 
-                nn.Conv2d(inp, oup, 1, 1, 0, bias=False), 
-                nn.BatchNorm2d(oup), 
-                nn.ReLU(inplace=True)
-                ]
+                nn.Conv2d(inp, inp, 3, 1, 1, groups=inp, bias=False),
+                nn.AvgPool2d(stride),
+                nn.BatchNorm2d(inp),
+                nn.ReLU(inplace=True),
+                nn.Conv2d(inp, oup, 1, 1, 0, bias=False),
+                nn.BatchNorm2d(oup),
+                nn.ReLU(inplace=True),
+            ]
             _layers = nn.Sequential(*_layers)
             init_layer(_layers[0])
             init_bn(_layers[2])
@@ -1361,9 +1653,9 @@ class MobileNetV1(nn.Module):
             return _layers
 
         self.features = nn.Sequential(
-            conv_bn(  1,  32, 2), 
-            conv_dw( 32,  64, 1),
-            conv_dw( 64, 128, 2),
+            conv_bn(1, 32, 2),
+            conv_dw(32, 64, 1),
+            conv_dw(64, 128, 2),
             conv_dw(128, 128, 1),
             conv_dw(128, 256, 2),
             conv_dw(256, 256, 1),
@@ -1374,7 +1666,8 @@ class MobileNetV1(nn.Module):
             conv_dw(512, 512, 1),
             conv_dw(512, 512, 1),
             conv_dw(512, 1024, 2),
-            conv_dw(1024, 1024, 1))
+            conv_dw(1024, 1024, 1),
+        )
 
         self.fc1 = nn.Linear(1024, 1024, bias=True)
         self.fc_audioset = nn.Linear(1024, classes_num, bias=True)
@@ -1385,28 +1678,28 @@ class MobileNetV1(nn.Module):
         init_bn(self.bn0)
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
 
-        x = self.spectrogram_extractor(input)   # (batch_size, 1, time_steps, freq_bins)
-        x = self.logmel_extractor(x)    # (batch_size, 1, time_steps, mel_bins)
-        
+        x = self.spectrogram_extractor(input)  # (batch_size, 1, time_steps, freq_bins)
+        x = self.logmel_extractor(x)  # (batch_size, 1, time_steps, mel_bins)
+
         x = x.transpose(1, 3)
         x = self.bn0(x)
         x = x.transpose(1, 3)
-        
+
         if self.training:
             x = self.spec_augmenter(x)
 
         # Mixup on spectrogram
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
-        
+
         x = self.features(x)
         x = torch.mean(x, dim=3)
-        
+
         (x1, _) = torch.max(x, dim=2)
         x2 = torch.mean(x, dim=2)
         x = x1 + x2
@@ -1414,8 +1707,8 @@ class MobileNetV1(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
@@ -1431,13 +1724,15 @@ class InvertedResidual(nn.Module):
 
         if expand_ratio == 1:
             _layers = [
-                nn.Conv2d(hidden_dim, hidden_dim, 3, 1, 1, groups=hidden_dim, bias=False), 
-                nn.AvgPool2d(stride), 
-                nn.BatchNorm2d(hidden_dim), 
-                nn.ReLU6(inplace=True), 
-                nn.Conv2d(hidden_dim, oup, 1, 1, 0, bias=False), 
-                nn.BatchNorm2d(oup)
-                ]
+                nn.Conv2d(
+                    hidden_dim, hidden_dim, 3, 1, 1, groups=hidden_dim, bias=False
+                ),
+                nn.AvgPool2d(stride),
+                nn.BatchNorm2d(hidden_dim),
+                nn.ReLU6(inplace=True),
+                nn.Conv2d(hidden_dim, oup, 1, 1, 0, bias=False),
+                nn.BatchNorm2d(oup),
+            ]
             _layers = nn.Sequential(*_layers)
             init_layer(_layers[0])
             init_bn(_layers[2])
@@ -1446,16 +1741,18 @@ class InvertedResidual(nn.Module):
             self.conv = _layers
         else:
             _layers = [
-                nn.Conv2d(inp, hidden_dim, 1, 1, 0, bias=False), 
-                nn.BatchNorm2d(hidden_dim), 
-                nn.ReLU6(inplace=True), 
-                nn.Conv2d(hidden_dim, hidden_dim, 3, 1, 1, groups=hidden_dim, bias=False), 
-                nn.AvgPool2d(stride), 
-                nn.BatchNorm2d(hidden_dim), 
-                nn.ReLU6(inplace=True), 
-                nn.Conv2d(hidden_dim, oup, 1, 1, 0, bias=False), 
-                nn.BatchNorm2d(oup)
-                ]
+                nn.Conv2d(inp, hidden_dim, 1, 1, 0, bias=False),
+                nn.BatchNorm2d(hidden_dim),
+                nn.ReLU6(inplace=True),
+                nn.Conv2d(
+                    hidden_dim, hidden_dim, 3, 1, 1, groups=hidden_dim, bias=False
+                ),
+                nn.AvgPool2d(stride),
+                nn.BatchNorm2d(hidden_dim),
+                nn.ReLU6(inplace=True),
+                nn.Conv2d(hidden_dim, oup, 1, 1, 0, bias=False),
+                nn.BatchNorm2d(oup),
+            ]
             _layers = nn.Sequential(*_layers)
             init_layer(_layers[0])
             init_bn(_layers[1])
@@ -1473,35 +1770,53 @@ class InvertedResidual(nn.Module):
 
 
 class MobileNetV2(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(MobileNetV2, self).__init__()
 
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
         ref = 1.0
         amin = 1e-10
         top_db = None
 
         # Spectrogram extractor
-        self.spectrogram_extractor = Spectrogram(n_fft=window_size, hop_length=hop_size, 
-            win_length=window_size, window=window, center=center, pad_mode=pad_mode, 
-            freeze_parameters=True)
+        self.spectrogram_extractor = Spectrogram(
+            n_fft=window_size,
+            hop_length=hop_size,
+            win_length=window_size,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         # Logmel feature extractor
-        self.logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=window_size, 
-            n_mels=mel_bins, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db, 
-            freeze_parameters=True)
+        self.logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=window_size,
+            n_mels=mel_bins,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         # Spec augmenter
-        self.spec_augmenter = SpecAugmentation(time_drop_width=64, time_stripes_num=2, 
-            freq_drop_width=8, freq_stripes_num=2)
+        self.spec_augmenter = SpecAugmentation(
+            time_drop_width=64,
+            time_stripes_num=2,
+            freq_drop_width=8,
+            freq_stripes_num=2,
+        )
 
         self.bn0 = nn.BatchNorm2d(64)
- 
-        width_mult=1.
+
+        width_mult = 1.0
         block = InvertedResidual
         input_channel = 32
         last_channel = 1280
@@ -1518,22 +1833,21 @@ class MobileNetV2(nn.Module):
 
         def conv_bn(inp, oup, stride):
             _layers = [
-                nn.Conv2d(inp, oup, 3, 1, 1, bias=False), 
-                nn.AvgPool2d(stride), 
-                nn.BatchNorm2d(oup), 
-                nn.ReLU6(inplace=True)
-                ]
+                nn.Conv2d(inp, oup, 3, 1, 1, bias=False),
+                nn.AvgPool2d(stride),
+                nn.BatchNorm2d(oup),
+                nn.ReLU6(inplace=True),
+            ]
             _layers = nn.Sequential(*_layers)
             init_layer(_layers[0])
             init_bn(_layers[2])
             return _layers
 
-
         def conv_1x1_bn(inp, oup):
             _layers = nn.Sequential(
                 nn.Conv2d(inp, oup, 1, 1, 0, bias=False),
                 nn.BatchNorm2d(oup),
-                nn.ReLU6(inplace=True)
+                nn.ReLU6(inplace=True),
             )
             init_layer(_layers[0])
             init_bn(_layers[1])
@@ -1541,16 +1855,22 @@ class MobileNetV2(nn.Module):
 
         # building first layer
         input_channel = int(input_channel * width_mult)
-        self.last_channel = int(last_channel * width_mult) if width_mult > 1.0 else last_channel
+        self.last_channel = (
+            int(last_channel * width_mult) if width_mult > 1.0 else last_channel
+        )
         self.features = [conv_bn(1, input_channel, 2)]
         # building inverted residual blocks
         for t, c, n, s in interverted_residual_setting:
             output_channel = int(c * width_mult)
             for i in range(n):
                 if i == 0:
-                    self.features.append(block(input_channel, output_channel, s, expand_ratio=t))
+                    self.features.append(
+                        block(input_channel, output_channel, s, expand_ratio=t)
+                    )
                 else:
-                    self.features.append(block(input_channel, output_channel, 1, expand_ratio=t))
+                    self.features.append(
+                        block(input_channel, output_channel, 1, expand_ratio=t)
+                    )
                 input_channel = output_channel
         # building last several layers
         self.features.append(conv_1x1_bn(input_channel, self.last_channel))
@@ -1559,36 +1879,36 @@ class MobileNetV2(nn.Module):
 
         self.fc1 = nn.Linear(1280, 1024, bias=True)
         self.fc_audioset = nn.Linear(1024, classes_num, bias=True)
-        
+
         self.init_weight()
 
     def init_weight(self):
         init_bn(self.bn0)
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
 
-        x = self.spectrogram_extractor(input)   # (batch_size, 1, time_steps, freq_bins)
-        x = self.logmel_extractor(x)    # (batch_size, 1, time_steps, mel_bins)
-        
+        x = self.spectrogram_extractor(input)  # (batch_size, 1, time_steps, freq_bins)
+        x = self.logmel_extractor(x)  # (batch_size, 1, time_steps, mel_bins)
+
         x = x.transpose(1, 3)
         x = self.bn0(x)
         x = x.transpose(1, 3)
-        
+
         if self.training:
             x = self.spec_augmenter(x)
 
         # Mixup on spectrogram
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
-        
+
         x = self.features(x)
-        
+
         x = torch.mean(x, dim=3)
-        
+
         (x1, _) = torch.max(x, dim=2)
         x2 = torch.mean(x, dim=2)
         x = x1 + x2
@@ -1596,26 +1916,29 @@ class MobileNetV2(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 class LeeNetConvBlock(nn.Module):
     def __init__(self, in_channels, out_channels, kernel_size, stride):
-        
         super(LeeNetConvBlock, self).__init__()
-        
-        self.conv1 = nn.Conv1d(in_channels=in_channels, 
-                              out_channels=out_channels,
-                              kernel_size=kernel_size, stride=stride,
-                              padding=kernel_size // 2, bias=False)
-                              
+
+        self.conv1 = nn.Conv1d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=kernel_size // 2,
+            bias=False,
+        )
+
         self.bn1 = nn.BatchNorm1d(out_channels)
 
         self.init_weight()
-        
+
     def init_weight(self):
         init_layer(self.conv1)
         init_bn(self.bn1)
@@ -1628,17 +1951,10 @@ class LeeNetConvBlock(nn.Module):
 
 
 class LeeNet11(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(LeeNet11, self).__init__()
-
-        window = 'hann'
-        center = True
-        pad_mode = 'reflect'
-        ref = 1.0
-        amin = 1e-10
-        top_db = None
 
         self.conv_block1 = LeeNetConvBlock(1, 64, 3, 3)
         self.conv_block2 = LeeNetConvBlock(64, 64, 3, 1)
@@ -1649,17 +1965,16 @@ class LeeNet11(nn.Module):
         self.conv_block7 = LeeNetConvBlock(128, 128, 3, 1)
         self.conv_block8 = LeeNetConvBlock(128, 128, 3, 1)
         self.conv_block9 = LeeNetConvBlock(128, 256, 3, 1)
-        
 
         self.fc1 = nn.Linear(256, 512, bias=True)
         self.fc_audioset = nn.Linear(512, classes_num, bias=True)
-        
+
         self.init_weight()
 
     def init_weight(self):
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
@@ -1669,7 +1984,7 @@ class LeeNet11(nn.Module):
         # Mixup on spectrogram
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
-        
+
         x = self.conv_block1(x)
         x = self.conv_block2(x, pool_size=3)
         x = self.conv_block3(x, pool_size=3)
@@ -1679,7 +1994,7 @@ class LeeNet11(nn.Module):
         x = self.conv_block7(x, pool_size=3)
         x = self.conv_block8(x, pool_size=3)
         x = self.conv_block9(x, pool_size=3)
-        
+
         (x1, _) = torch.max(x, dim=2)
         x2 = torch.mean(x, dim=2)
         x = x1 + x2
@@ -1687,32 +2002,39 @@ class LeeNet11(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 class LeeNetConvBlock2(nn.Module):
     def __init__(self, in_channels, out_channels, kernel_size, stride):
-        
         super(LeeNetConvBlock2, self).__init__()
-        
-        self.conv1 = nn.Conv1d(in_channels=in_channels, 
-                              out_channels=out_channels,
-                              kernel_size=kernel_size, stride=stride,
-                              padding=kernel_size // 2, bias=False)
-                              
-        self.conv2 = nn.Conv1d(in_channels=out_channels, 
-                              out_channels=out_channels,
-                              kernel_size=kernel_size, stride=1,
-                              padding=kernel_size // 2, bias=False)
+
+        self.conv1 = nn.Conv1d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=kernel_size // 2,
+            bias=False,
+        )
+
+        self.conv2 = nn.Conv1d(
+            in_channels=out_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=1,
+            padding=kernel_size // 2,
+            bias=False,
+        )
 
         self.bn1 = nn.BatchNorm1d(out_channels)
         self.bn2 = nn.BatchNorm1d(out_channels)
 
         self.init_weight()
-        
+
     def init_weight(self):
         init_layer(self.conv1)
         init_layer(self.conv2)
@@ -1728,17 +2050,10 @@ class LeeNetConvBlock2(nn.Module):
 
 
 class LeeNet24(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(LeeNet24, self).__init__()
-
-        window = 'hann'
-        center = True
-        pad_mode = 'reflect'
-        ref = 1.0
-        amin = 1e-10
-        top_db = None
 
         self.conv_block1 = LeeNetConvBlock2(1, 64, 3, 3)
         self.conv_block2 = LeeNetConvBlock2(64, 96, 3, 1)
@@ -1752,13 +2067,13 @@ class LeeNet24(nn.Module):
 
         self.fc1 = nn.Linear(1024, 1024, bias=True)
         self.fc_audioset = nn.Linear(1024, classes_num, bias=True)
-        
+
         self.init_weight()
 
     def init_weight(self):
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
@@ -1768,7 +2083,7 @@ class LeeNet24(nn.Module):
         # Mixup on spectrogram
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
-        
+
         x = self.conv_block1(x)
         x = F.dropout(x, p=0.1, training=self.training)
         x = self.conv_block2(x, pool_size=3)
@@ -1794,41 +2109,60 @@ class LeeNet24(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 class DaiNetResBlock(nn.Module):
     def __init__(self, in_channels, out_channels, kernel_size):
-        
         super(DaiNetResBlock, self).__init__()
-        
-        self.conv1 = nn.Conv1d(in_channels=in_channels, 
-                              out_channels=out_channels,
-                              kernel_size=kernel_size, stride=1,
-                              padding=kernel_size // 2, bias=False)
 
-        self.conv2 = nn.Conv1d(in_channels=out_channels, 
-                              out_channels=out_channels,
-                              kernel_size=kernel_size, stride=1,
-                              padding=kernel_size // 2, bias=False)
+        self.conv1 = nn.Conv1d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=1,
+            padding=kernel_size // 2,
+            bias=False,
+        )
 
-        self.conv3 = nn.Conv1d(in_channels=out_channels, 
-                              out_channels=out_channels,
-                              kernel_size=kernel_size, stride=1,
-                              padding=kernel_size // 2, bias=False)
+        self.conv2 = nn.Conv1d(
+            in_channels=out_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=1,
+            padding=kernel_size // 2,
+            bias=False,
+        )
 
-        self.conv4 = nn.Conv1d(in_channels=out_channels, 
-                              out_channels=out_channels,
-                              kernel_size=kernel_size, stride=1,
-                              padding=kernel_size // 2, bias=False)
+        self.conv3 = nn.Conv1d(
+            in_channels=out_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=1,
+            padding=kernel_size // 2,
+            bias=False,
+        )
 
-        self.downsample = nn.Conv1d(in_channels=in_channels, 
-                              out_channels=out_channels,
-                              kernel_size=1, stride=1,
-                              padding=0, bias=False)
+        self.conv4 = nn.Conv1d(
+            in_channels=out_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=1,
+            padding=kernel_size // 2,
+            bias=False,
+        )
+
+        self.downsample = nn.Conv1d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            bias=False,
+        )
 
         self.bn1 = nn.BatchNorm1d(out_channels)
         self.bn2 = nn.BatchNorm1d(out_channels)
@@ -1837,7 +2171,7 @@ class DaiNetResBlock(nn.Module):
         self.bn_downsample = nn.BatchNorm1d(out_channels)
 
         self.init_weight()
-        
+
     def init_weight(self):
         init_layer(self.conv1)
         init_layer(self.conv2)
@@ -1867,19 +2201,19 @@ class DaiNetResBlock(nn.Module):
 
 
 class DaiNet19(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(DaiNet19, self).__init__()
 
-        window = 'hann'
-        center = True
-        pad_mode = 'reflect'
-        ref = 1.0
-        amin = 1e-10
-        top_db = None
-
-        self.conv0 = nn.Conv1d(in_channels=1, out_channels=64, kernel_size=80, stride=4, padding=0, bias=False)
+        self.conv0 = nn.Conv1d(
+            in_channels=1,
+            out_channels=64,
+            kernel_size=80,
+            stride=4,
+            padding=0,
+            bias=False,
+        )
         self.bn0 = nn.BatchNorm1d(64)
         self.conv_block1 = DaiNetResBlock(64, 64, 3)
         self.conv_block2 = DaiNetResBlock(64, 128, 3)
@@ -1888,7 +2222,7 @@ class DaiNet19(nn.Module):
 
         self.fc1 = nn.Linear(512, 512, bias=True)
         self.fc_audioset = nn.Linear(512, classes_num, bias=True)
-        
+
         self.init_weight()
 
     def init_weight(self):
@@ -1896,7 +2230,7 @@ class DaiNet19(nn.Module):
         init_bn(self.bn0)
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
@@ -1923,33 +2257,52 @@ class DaiNet19(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 def _resnet_conv3x1_wav1d(in_planes, out_planes, dilation):
-    #3x3 convolution with padding
-    return nn.Conv1d(in_planes, out_planes, kernel_size=3, stride=1,
-                     padding=dilation, groups=1, bias=False, dilation=dilation)
+    # 3x3 convolution with padding
+    return nn.Conv1d(
+        in_planes,
+        out_planes,
+        kernel_size=3,
+        stride=1,
+        padding=dilation,
+        groups=1,
+        bias=False,
+        dilation=dilation,
+    )
 
 
 def _resnet_conv1x1_wav1d(in_planes, out_planes):
-    #1x1 convolution
+    # 1x1 convolution
     return nn.Conv1d(in_planes, out_planes, kernel_size=1, stride=1, bias=False)
 
 
 class _ResnetBasicBlockWav1d(nn.Module):
     expansion = 1
 
-    def __init__(self, inplanes, planes, stride=1, downsample=None, groups=1,
-                 base_width=64, dilation=1, norm_layer=None):
+    def __init__(
+        self,
+        inplanes,
+        planes,
+        stride=1,
+        downsample=None,
+        groups=1,
+        base_width=64,
+        dilation=1,
+        norm_layer=None,
+    ):
         super(_ResnetBasicBlockWav1d, self).__init__()
         if norm_layer is None:
             norm_layer = nn.BatchNorm1d
         if groups != 1 or base_width != 64:
-            raise ValueError('_ResnetBasicBlock only supports groups=1 and base_width=64')
+            raise ValueError(
+                "_ResnetBasicBlock only supports groups=1 and base_width=64"
+            )
         if dilation > 1:
             raise NotImplementedError("Dilation > 1 not supported in _ResnetBasicBlock")
         # Both self.conv1 and self.downsample layers downsample the input when stride != 1
@@ -1988,7 +2341,7 @@ class _ResnetBasicBlockWav1d(nn.Module):
 
         out = self.conv2(out)
         out = self.bn2(out)
-        
+
         if self.downsample is not None:
             identity = self.downsample(identity)
 
@@ -1999,9 +2352,16 @@ class _ResnetBasicBlockWav1d(nn.Module):
 
 
 class _ResNetWav1d(nn.Module):
-    def __init__(self, block, layers, zero_init_residual=False,
-                 groups=1, width_per_group=64, replace_stride_with_dilation=None,
-                 norm_layer=None):
+    def __init__(
+        self,
+        block,
+        layers,
+        zero_init_residual=False,
+        groups=1,
+        width_per_group=64,
+        replace_stride_with_dilation=None,
+        norm_layer=None,
+    ):
         super(_ResNetWav1d, self).__init__()
 
         if norm_layer is None:
@@ -2015,8 +2375,10 @@ class _ResNetWav1d(nn.Module):
             # the 2x2 stride with a dilated convolution instead
             replace_stride_with_dilation = [False, False, False]
         if len(replace_stride_with_dilation) != 3:
-            raise ValueError("replace_stride_with_dilation should be None "
-                             "or a 3-element tuple, got {}".format(replace_stride_with_dilation))
+            raise ValueError(
+                "replace_stride_with_dilation should be None "
+                "or a 3-element tuple, got {}".format(replace_stride_with_dilation)
+            )
         self.groups = groups
         self.base_width = width_per_group
 
@@ -2045,7 +2407,7 @@ class _ResNetWav1d(nn.Module):
                 init_bn(downsample[1])
             else:
                 downsample = nn.Sequential(
-                    nn.AvgPool1d(kernel_size=stride), 
+                    nn.AvgPool1d(kernel_size=stride),
                     _resnet_conv1x1_wav1d(self.inplanes, planes * block.expansion),
                     norm_layer(planes * block.expansion),
                 )
@@ -2053,18 +2415,34 @@ class _ResNetWav1d(nn.Module):
                 init_bn(downsample[2])
 
         layers = []
-        layers.append(block(self.inplanes, planes, stride, downsample, self.groups,
-                            self.base_width, previous_dilation, norm_layer))
+        layers.append(
+            block(
+                self.inplanes,
+                planes,
+                stride,
+                downsample,
+                self.groups,
+                self.base_width,
+                previous_dilation,
+                norm_layer,
+            )
+        )
         self.inplanes = planes * block.expansion
         for _ in range(1, blocks):
-            layers.append(block(self.inplanes, planes, groups=self.groups,
-                                base_width=self.base_width, dilation=self.dilation,
-                                norm_layer=norm_layer))
+            layers.append(
+                block(
+                    self.inplanes,
+                    planes,
+                    groups=self.groups,
+                    base_width=self.base_width,
+                    dilation=self.dilation,
+                    norm_layer=norm_layer,
+                )
+            )
 
         return nn.Sequential(*layers)
 
     def forward(self, x):
-        
         x = self.layer1(x)
         x = self.layer2(x)
         x = self.layer3(x)
@@ -2077,26 +2455,26 @@ class _ResNetWav1d(nn.Module):
 
 
 class Res1dNet31(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(Res1dNet31, self).__init__()
 
-        window = 'hann'
-        center = True
-        pad_mode = 'reflect'
-        ref = 1.0
-        amin = 1e-10
-        top_db = None
-
-        self.conv0 = nn.Conv1d(in_channels=1, out_channels=64, kernel_size=11, stride=5, padding=5, bias=False)
+        self.conv0 = nn.Conv1d(
+            in_channels=1,
+            out_channels=64,
+            kernel_size=11,
+            stride=5,
+            padding=5,
+            bias=False,
+        )
         self.bn0 = nn.BatchNorm1d(64)
 
         self.resnet = _ResNetWav1d(_ResnetBasicBlockWav1d, [2, 2, 2, 2, 2, 2, 2])
 
         self.fc1 = nn.Linear(2048, 2048, bias=True)
         self.fc_audioset = nn.Linear(2048, classes_num, bias=True)
-         
+
         self.init_weight()
 
     def init_weight(self):
@@ -2104,7 +2482,7 @@ class Res1dNet31(nn.Module):
         init_bn(self.bn0)
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
@@ -2125,33 +2503,33 @@ class Res1dNet31(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 class Res1dNet51(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(Res1dNet51, self).__init__()
 
-        window = 'hann'
-        center = True
-        pad_mode = 'reflect'
-        ref = 1.0
-        amin = 1e-10
-        top_db = None
-
-        self.conv0 = nn.Conv1d(in_channels=1, out_channels=64, kernel_size=11, stride=5, padding=5, bias=False)
+        self.conv0 = nn.Conv1d(
+            in_channels=1,
+            out_channels=64,
+            kernel_size=11,
+            stride=5,
+            padding=5,
+            bias=False,
+        )
         self.bn0 = nn.BatchNorm1d(64)
 
         self.resnet = _ResNetWav1d(_ResnetBasicBlockWav1d, [2, 3, 4, 6, 4, 3, 2])
 
         self.fc1 = nn.Linear(2048, 2048, bias=True)
         self.fc_audioset = nn.Linear(2048, classes_num, bias=True)
-         
+
         self.init_weight()
 
     def init_weight(self):
@@ -2159,7 +2537,7 @@ class Res1dNet51(nn.Module):
         init_bn(self.bn0)
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
@@ -2180,63 +2558,69 @@ class Res1dNet51(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 class ConvPreWavBlock(nn.Module):
     def __init__(self, in_channels, out_channels):
-        
         super(ConvPreWavBlock, self).__init__()
-        
-        self.conv1 = nn.Conv1d(in_channels=in_channels, 
-                              out_channels=out_channels,
-                              kernel_size=3, stride=1,
-                              padding=1, bias=False)
-                              
-        self.conv2 = nn.Conv1d(in_channels=out_channels, 
-                              out_channels=out_channels,
-                              kernel_size=3, stride=1, dilation=2, 
-                              padding=2, bias=False)
-                              
+
+        self.conv1 = nn.Conv1d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            bias=False,
+        )
+
+        self.conv2 = nn.Conv1d(
+            in_channels=out_channels,
+            out_channels=out_channels,
+            kernel_size=3,
+            stride=1,
+            dilation=2,
+            padding=2,
+            bias=False,
+        )
+
         self.bn1 = nn.BatchNorm1d(out_channels)
         self.bn2 = nn.BatchNorm1d(out_channels)
 
         self.init_weight()
-        
+
     def init_weight(self):
         init_layer(self.conv1)
         init_layer(self.conv2)
         init_bn(self.bn1)
         init_bn(self.bn2)
 
-        
     def forward(self, input, pool_size):
-        
         x = input
         x = F.relu_(self.bn1(self.conv1(x)))
         x = F.relu_(self.bn2(self.conv2(x)))
         x = F.max_pool1d(x, kernel_size=pool_size)
-        
+
         return x
 
 
 class Wavegram_Cnn14(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(Wavegram_Cnn14, self).__init__()
 
-        window = 'hann'
-        center = True
-        pad_mode = 'reflect'
-        ref = 1.0
-        amin = 1e-10
-        top_db = None
-
-        self.pre_conv0 = nn.Conv1d(in_channels=1, out_channels=64, kernel_size=11, stride=5, padding=5, bias=False)
+        self.pre_conv0 = nn.Conv1d(
+            in_channels=1,
+            out_channels=64,
+            kernel_size=11,
+            stride=5,
+            padding=5,
+            bias=False,
+        )
         self.pre_bn0 = nn.BatchNorm1d(64)
         self.pre_block1 = ConvPreWavBlock(64, 64)
         self.pre_block2 = ConvPreWavBlock(64, 128)
@@ -2244,8 +2628,12 @@ class Wavegram_Cnn14(nn.Module):
         self.pre_block4 = ConvBlock(in_channels=4, out_channels=64)
 
         # Spec augmenter
-        self.spec_augmenter = SpecAugmentation(time_drop_width=64, time_stripes_num=2, 
-            freq_drop_width=8, freq_stripes_num=2)
+        self.spec_augmenter = SpecAugmentation(
+            time_drop_width=64,
+            time_stripes_num=2,
+            freq_drop_width=8,
+            freq_stripes_num=2,
+        )
 
         self.bn0 = nn.BatchNorm2d(64)
 
@@ -2258,7 +2646,7 @@ class Wavegram_Cnn14(nn.Module):
 
         self.fc1 = nn.Linear(2048, 2048, bias=True)
         self.fc_audioset = nn.Linear(2048, classes_num, bias=True)
-        
+
         self.init_weight()
 
     def init_weight(self):
@@ -2267,7 +2655,7 @@ class Wavegram_Cnn14(nn.Module):
         init_bn(self.bn0)
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
@@ -2283,21 +2671,21 @@ class Wavegram_Cnn14(nn.Module):
         # Mixup on spectrogram
         if self.training and mixup_lambda is not None:
             a1 = do_mixup(a1, mixup_lambda)
-        
+
         x = a1
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block2(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block2(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block3(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block3(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block4(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block4(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block5(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block5(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block6(x, pool_size=(1, 1), pool_type='avg')
+        x = self.conv_block6(x, pool_size=(1, 1), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
         x = torch.mean(x, dim=3)
-        
+
         (x1, _) = torch.max(x, dim=2)
         x2 = torch.mean(x, dim=2)
         x = x1 + x2
@@ -2305,26 +2693,33 @@ class Wavegram_Cnn14(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 class Wavegram_Logmel_Cnn14(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(Wavegram_Logmel_Cnn14, self).__init__()
 
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
         ref = 1.0
         amin = 1e-10
         top_db = None
 
-        self.pre_conv0 = nn.Conv1d(in_channels=1, out_channels=64, kernel_size=11, stride=5, padding=5, bias=False)
+        self.pre_conv0 = nn.Conv1d(
+            in_channels=1,
+            out_channels=64,
+            kernel_size=11,
+            stride=5,
+            padding=5,
+            bias=False,
+        )
         self.pre_bn0 = nn.BatchNorm1d(64)
         self.pre_block1 = ConvPreWavBlock(64, 64)
         self.pre_block2 = ConvPreWavBlock(64, 128)
@@ -2332,18 +2727,36 @@ class Wavegram_Logmel_Cnn14(nn.Module):
         self.pre_block4 = ConvBlock(in_channels=4, out_channels=64)
 
         # Spectrogram extractor
-        self.spectrogram_extractor = Spectrogram(n_fft=window_size, hop_length=hop_size, 
-            win_length=window_size, window=window, center=center, pad_mode=pad_mode, 
-            freeze_parameters=True)
+        self.spectrogram_extractor = Spectrogram(
+            n_fft=window_size,
+            hop_length=hop_size,
+            win_length=window_size,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         # Logmel feature extractor
-        self.logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=window_size, 
-            n_mels=mel_bins, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db, 
-            freeze_parameters=True)
+        self.logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=window_size,
+            n_mels=mel_bins,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         # Spec augmenter
-        self.spec_augmenter = SpecAugmentation(time_drop_width=64, time_stripes_num=2, 
-            freq_drop_width=8, freq_stripes_num=2)
+        self.spec_augmenter = SpecAugmentation(
+            time_drop_width=64,
+            time_stripes_num=2,
+            freq_drop_width=8,
+            freq_stripes_num=2,
+        )
 
         self.bn0 = nn.BatchNorm2d(64)
 
@@ -2356,7 +2769,7 @@ class Wavegram_Logmel_Cnn14(nn.Module):
 
         self.fc1 = nn.Linear(2048, 2048, bias=True)
         self.fc_audioset = nn.Linear(2048, classes_num, bias=True)
-        
+
         self.init_weight()
 
     def init_weight(self):
@@ -2365,7 +2778,7 @@ class Wavegram_Logmel_Cnn14(nn.Module):
         init_bn(self.bn0)
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
@@ -2379,9 +2792,9 @@ class Wavegram_Logmel_Cnn14(nn.Module):
         a1 = self.pre_block4(a1, pool_size=(2, 1))
 
         # Log mel spectrogram
-        x = self.spectrogram_extractor(input)   # (batch_size, 1, time_steps, freq_bins)
-        x = self.logmel_extractor(x)    # (batch_size, 1, time_steps, mel_bins)
-        
+        x = self.spectrogram_extractor(input)  # (batch_size, 1, time_steps, freq_bins)
+        x = self.logmel_extractor(x)  # (batch_size, 1, time_steps, mel_bins)
+
         x = x.transpose(1, 3)
         x = self.bn0(x)
         x = x.transpose(1, 3)
@@ -2393,25 +2806,25 @@ class Wavegram_Logmel_Cnn14(nn.Module):
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
             a1 = do_mixup(a1, mixup_lambda)
-        
-        x = self.conv_block1(x, pool_size=(2, 2), pool_type='avg')
+
+        x = self.conv_block1(x, pool_size=(2, 2), pool_type="avg")
 
         # Concatenate Wavegram and Log mel spectrogram along the channel dimension
         x = torch.cat((x, a1), dim=1)
 
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block2(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block2(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block3(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block3(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block4(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block4(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block5(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block5(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block6(x, pool_size=(1, 1), pool_type='avg')
+        x = self.conv_block6(x, pool_size=(1, 1), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
         x = torch.mean(x, dim=3)
-        
+
         (x1, _) = torch.max(x, dim=2)
         x2 = torch.mean(x, dim=2)
         x = x1 + x2
@@ -2419,26 +2832,33 @@ class Wavegram_Logmel_Cnn14(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 class Wavegram_Logmel128_Cnn14(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(Wavegram_Logmel128_Cnn14, self).__init__()
 
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
         ref = 1.0
         amin = 1e-10
         top_db = None
 
-        self.pre_conv0 = nn.Conv1d(in_channels=1, out_channels=64, kernel_size=11, stride=5, padding=5, bias=False)
+        self.pre_conv0 = nn.Conv1d(
+            in_channels=1,
+            out_channels=64,
+            kernel_size=11,
+            stride=5,
+            padding=5,
+            bias=False,
+        )
         self.pre_bn0 = nn.BatchNorm1d(64)
         self.pre_block1 = ConvPreWavBlock(64, 64)
         self.pre_block2 = ConvPreWavBlock(64, 128)
@@ -2446,18 +2866,36 @@ class Wavegram_Logmel128_Cnn14(nn.Module):
         self.pre_block4 = ConvBlock(in_channels=4, out_channels=64)
 
         # Spectrogram extractor
-        self.spectrogram_extractor = Spectrogram(n_fft=window_size, hop_length=hop_size, 
-            win_length=window_size, window=window, center=center, pad_mode=pad_mode, 
-            freeze_parameters=True)
+        self.spectrogram_extractor = Spectrogram(
+            n_fft=window_size,
+            hop_length=hop_size,
+            win_length=window_size,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         # Logmel feature extractor
-        self.logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=window_size, 
-            n_mels=mel_bins, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db, 
-            freeze_parameters=True)
+        self.logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=window_size,
+            n_mels=mel_bins,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         # Spec augmenter
-        self.spec_augmenter = SpecAugmentation(time_drop_width=64, time_stripes_num=2, 
-            freq_drop_width=16, freq_stripes_num=2)
+        self.spec_augmenter = SpecAugmentation(
+            time_drop_width=64,
+            time_stripes_num=2,
+            freq_drop_width=16,
+            freq_stripes_num=2,
+        )
 
         self.bn0 = nn.BatchNorm2d(128)
 
@@ -2470,7 +2908,7 @@ class Wavegram_Logmel128_Cnn14(nn.Module):
 
         self.fc1 = nn.Linear(2048, 2048, bias=True)
         self.fc_audioset = nn.Linear(2048, classes_num, bias=True)
-        
+
         self.init_weight()
 
     def init_weight(self):
@@ -2479,7 +2917,7 @@ class Wavegram_Logmel128_Cnn14(nn.Module):
         init_bn(self.bn0)
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
@@ -2493,9 +2931,9 @@ class Wavegram_Logmel128_Cnn14(nn.Module):
         a1 = self.pre_block4(a1, pool_size=(2, 1))
 
         # Log mel spectrogram
-        x = self.spectrogram_extractor(input)   # (batch_size, 1, time_steps, freq_bins)
-        x = self.logmel_extractor(x)    # (batch_size, 1, time_steps, mel_bins)
-        
+        x = self.spectrogram_extractor(input)  # (batch_size, 1, time_steps, freq_bins)
+        x = self.logmel_extractor(x)  # (batch_size, 1, time_steps, mel_bins)
+
         x = x.transpose(1, 3)
         x = self.bn0(x)
         x = x.transpose(1, 3)
@@ -2507,25 +2945,25 @@ class Wavegram_Logmel128_Cnn14(nn.Module):
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
             a1 = do_mixup(a1, mixup_lambda)
-        
-        x = self.conv_block1(x, pool_size=(2, 2), pool_type='avg')
+
+        x = self.conv_block1(x, pool_size=(2, 2), pool_type="avg")
 
         # Concatenate Wavegram and Log mel spectrogram along the channel dimension
         x = torch.cat((x, a1), dim=1)
-        
+
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block2(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block2(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block3(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block3(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block4(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block4(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block5(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block5(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block6(x, pool_size=(1, 1), pool_type='avg')
+        x = self.conv_block6(x, pool_size=(1, 1), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
         x = torch.mean(x, dim=3)
-        
+
         (x1, _) = torch.max(x, dim=2)
         x2 = torch.mean(x, dim=2)
         x = x1 + x2
@@ -2533,16 +2971,17 @@ class Wavegram_Logmel128_Cnn14(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 class Cnn14_16k(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num):
-        
-        super(Cnn14_16k, self).__init__() 
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
+        super(Cnn14_16k, self).__init__()
 
         assert sample_rate == 16000
         assert window_size == 512
@@ -2551,26 +2990,44 @@ class Cnn14_16k(nn.Module):
         assert fmin == 50
         assert fmax == 8000
 
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
         ref = 1.0
         amin = 1e-10
         top_db = None
 
         # Spectrogram extractor
-        self.spectrogram_extractor = Spectrogram(n_fft=window_size, hop_length=hop_size, 
-            win_length=window_size, window=window, center=center, pad_mode=pad_mode, 
-            freeze_parameters=True)
+        self.spectrogram_extractor = Spectrogram(
+            n_fft=window_size,
+            hop_length=hop_size,
+            win_length=window_size,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         # Logmel feature extractor
-        self.logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=window_size, 
-            n_mels=mel_bins, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db, 
-            freeze_parameters=True)
+        self.logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=window_size,
+            n_mels=mel_bins,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         # Spec augmenter
-        self.spec_augmenter = SpecAugmentation(time_drop_width=64, time_stripes_num=2, 
-            freq_drop_width=8, freq_stripes_num=2)
+        self.spec_augmenter = SpecAugmentation(
+            time_drop_width=64,
+            time_stripes_num=2,
+            freq_drop_width=8,
+            freq_stripes_num=2,
+        )
 
         self.bn0 = nn.BatchNorm2d(64)
 
@@ -2583,46 +3040,46 @@ class Cnn14_16k(nn.Module):
 
         self.fc1 = nn.Linear(2048, 2048, bias=True)
         self.fc_audioset = nn.Linear(2048, classes_num, bias=True)
-        
+
         self.init_weight()
 
     def init_weight(self):
         init_bn(self.bn0)
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
 
-        x = self.spectrogram_extractor(input)   # (batch_size, 1, time_steps, freq_bins)
-        x = self.logmel_extractor(x)    # (batch_size, 1, time_steps, mel_bins)
+        x = self.spectrogram_extractor(input)  # (batch_size, 1, time_steps, freq_bins)
+        x = self.logmel_extractor(x)  # (batch_size, 1, time_steps, mel_bins)
 
         x = x.transpose(1, 3)
         x = self.bn0(x)
         x = x.transpose(1, 3)
-        
+
         if self.training:
             x = self.spec_augmenter(x)
 
         # Mixup on spectrogram
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
-        
-        x = self.conv_block1(x, pool_size=(2, 2), pool_type='avg')
+
+        x = self.conv_block1(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block2(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block2(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block3(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block3(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block4(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block4(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block5(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block5(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block6(x, pool_size=(1, 1), pool_type='avg')
+        x = self.conv_block6(x, pool_size=(1, 1), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
         x = torch.mean(x, dim=3)
-        
+
         (x1, _) = torch.max(x, dim=2)
         x2 = torch.mean(x, dim=2)
         x = x1 + x2
@@ -2630,16 +3087,17 @@ class Cnn14_16k(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 class Cnn14_8k(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num):
-        
-        super(Cnn14_8k, self).__init__() 
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
+        super(Cnn14_8k, self).__init__()
 
         assert sample_rate == 8000
         assert window_size == 256
@@ -2648,26 +3106,44 @@ class Cnn14_8k(nn.Module):
         assert fmin == 50
         assert fmax == 4000
 
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
         ref = 1.0
         amin = 1e-10
         top_db = None
 
         # Spectrogram extractor
-        self.spectrogram_extractor = Spectrogram(n_fft=window_size, hop_length=hop_size, 
-            win_length=window_size, window=window, center=center, pad_mode=pad_mode, 
-            freeze_parameters=True)
+        self.spectrogram_extractor = Spectrogram(
+            n_fft=window_size,
+            hop_length=hop_size,
+            win_length=window_size,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         # Logmel feature extractor
-        self.logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=window_size, 
-            n_mels=mel_bins, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db, 
-            freeze_parameters=True)
+        self.logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=window_size,
+            n_mels=mel_bins,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         # Spec augmenter
-        self.spec_augmenter = SpecAugmentation(time_drop_width=64, time_stripes_num=2, 
-            freq_drop_width=8, freq_stripes_num=2)
+        self.spec_augmenter = SpecAugmentation(
+            time_drop_width=64,
+            time_stripes_num=2,
+            freq_drop_width=8,
+            freq_stripes_num=2,
+        )
 
         self.bn0 = nn.BatchNorm2d(64)
 
@@ -2680,46 +3156,46 @@ class Cnn14_8k(nn.Module):
 
         self.fc1 = nn.Linear(2048, 2048, bias=True)
         self.fc_audioset = nn.Linear(2048, classes_num, bias=True)
-        
+
         self.init_weight()
 
     def init_weight(self):
         init_bn(self.bn0)
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
 
-        x = self.spectrogram_extractor(input)   # (batch_size, 1, time_steps, freq_bins)
-        x = self.logmel_extractor(x)    # (batch_size, 1, time_steps, mel_bins)
+        x = self.spectrogram_extractor(input)  # (batch_size, 1, time_steps, freq_bins)
+        x = self.logmel_extractor(x)  # (batch_size, 1, time_steps, mel_bins)
 
         x = x.transpose(1, 3)
         x = self.bn0(x)
         x = x.transpose(1, 3)
-        
+
         if self.training:
             x = self.spec_augmenter(x)
 
         # Mixup on spectrogram
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
-        
-        x = self.conv_block1(x, pool_size=(2, 2), pool_type='avg')
+
+        x = self.conv_block1(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block2(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block2(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block3(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block3(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block4(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block4(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block5(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block5(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block6(x, pool_size=(1, 1), pool_type='avg')
+        x = self.conv_block6(x, pool_size=(1, 1), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
         x = torch.mean(x, dim=3)
-        
+
         (x1, _) = torch.max(x, dim=2)
         x2 = torch.mean(x, dim=2)
         x = x1 + x2
@@ -2727,38 +3203,56 @@ class Cnn14_8k(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 class Cnn14_mixup_time_domain(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(Cnn14_mixup_time_domain, self).__init__()
 
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
         ref = 1.0
         amin = 1e-10
         top_db = None
 
         # Spectrogram extractor
-        self.spectrogram_extractor = Spectrogram(n_fft=window_size, hop_length=hop_size, 
-            win_length=window_size, window=window, center=center, pad_mode=pad_mode, 
-            freeze_parameters=True)
+        self.spectrogram_extractor = Spectrogram(
+            n_fft=window_size,
+            hop_length=hop_size,
+            win_length=window_size,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         # Logmel feature extractor
-        self.logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=window_size, 
-            n_mels=mel_bins, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db, 
-            freeze_parameters=True)
+        self.logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=window_size,
+            n_mels=mel_bins,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         # Spec augmenter
-        self.spec_augmenter = SpecAugmentation(time_drop_width=64, time_stripes_num=2, 
-            freq_drop_width=8, freq_stripes_num=2)
+        self.spec_augmenter = SpecAugmentation(
+            time_drop_width=64,
+            time_stripes_num=2,
+            freq_drop_width=8,
+            freq_stripes_num=2,
+        )
 
         self.bn0 = nn.BatchNorm2d(64)
 
@@ -2771,14 +3265,14 @@ class Cnn14_mixup_time_domain(nn.Module):
 
         self.fc1 = nn.Linear(2048, 2048, bias=True)
         self.fc_audioset = nn.Linear(2048, classes_num, bias=True)
-        
+
         self.init_weight()
 
     def init_weight(self):
         init_bn(self.bn0)
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
@@ -2789,8 +3283,8 @@ class Cnn14_mixup_time_domain(nn.Module):
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
 
-        x = self.spectrogram_extractor(x)   # (batch_size, 1, time_steps, freq_bins)
-        x = self.logmel_extractor(x)    # (batch_size, 1, time_steps, mel_bins)
+        x = self.spectrogram_extractor(x)  # (batch_size, 1, time_steps, freq_bins)
+        x = self.logmel_extractor(x)  # (batch_size, 1, time_steps, mel_bins)
 
         x = x.transpose(1, 3)
         x = self.bn0(x)
@@ -2799,20 +3293,20 @@ class Cnn14_mixup_time_domain(nn.Module):
         if self.training:
             x = self.spec_augmenter(x)
 
-        x = self.conv_block1(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block1(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block2(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block2(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block3(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block3(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block4(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block4(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block5(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block5(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block6(x, pool_size=(1, 1), pool_type='avg')
+        x = self.conv_block6(x, pool_size=(1, 1), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
         x = torch.mean(x, dim=3)
-        
+
         (x1, _) = torch.max(x, dim=2)
         x2 = torch.mean(x, dim=2)
         x = x1 + x2
@@ -2820,38 +3314,56 @@ class Cnn14_mixup_time_domain(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 class Cnn14_mel32(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(Cnn14_mel32, self).__init__()
 
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
         ref = 1.0
         amin = 1e-10
         top_db = None
 
         # Spectrogram extractor
-        self.spectrogram_extractor = Spectrogram(n_fft=window_size, hop_length=hop_size, 
-            win_length=window_size, window=window, center=center, pad_mode=pad_mode, 
-            freeze_parameters=True)
+        self.spectrogram_extractor = Spectrogram(
+            n_fft=window_size,
+            hop_length=hop_size,
+            win_length=window_size,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         # Logmel feature extractor
-        self.logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=window_size, 
-            n_mels=mel_bins, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db, 
-            freeze_parameters=True)
+        self.logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=window_size,
+            n_mels=mel_bins,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         # Spec augmenter
-        self.spec_augmenter = SpecAugmentation(time_drop_width=64, time_stripes_num=2, 
-            freq_drop_width=4, freq_stripes_num=2)
+        self.spec_augmenter = SpecAugmentation(
+            time_drop_width=64,
+            time_stripes_num=2,
+            freq_drop_width=4,
+            freq_stripes_num=2,
+        )
 
         self.bn0 = nn.BatchNorm2d(32)
 
@@ -2864,25 +3376,25 @@ class Cnn14_mel32(nn.Module):
 
         self.fc1 = nn.Linear(2048, 2048, bias=True)
         self.fc_audioset = nn.Linear(2048, classes_num, bias=True)
-        
+
         self.init_weight()
 
     def init_weight(self):
         init_bn(self.bn0)
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
 
-        x = self.spectrogram_extractor(input)   # (batch_size, 1, time_steps, freq_bins)
-        x = self.logmel_extractor(x)    # (batch_size, 1, time_steps, mel_bins)
-        
+        x = self.spectrogram_extractor(input)  # (batch_size, 1, time_steps, freq_bins)
+        x = self.logmel_extractor(x)  # (batch_size, 1, time_steps, mel_bins)
+
         x = x.transpose(1, 3)
         x = self.bn0(x)
         x = x.transpose(1, 3)
-        
+
         if self.training:
             x = self.spec_augmenter(x)
 
@@ -2890,20 +3402,20 @@ class Cnn14_mel32(nn.Module):
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
 
-        x = self.conv_block1(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block1(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block2(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block2(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block3(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block3(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block4(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block4(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block5(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block5(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block6(x, pool_size=(1, 1), pool_type='avg')
+        x = self.conv_block6(x, pool_size=(1, 1), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
         x = torch.mean(x, dim=3)
-        
+
         (x1, _) = torch.max(x, dim=2)
         x2 = torch.mean(x, dim=2)
         x = x1 + x2
@@ -2911,38 +3423,56 @@ class Cnn14_mel32(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 class Cnn14_mel128(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(Cnn14_mel128, self).__init__()
 
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
         ref = 1.0
         amin = 1e-10
         top_db = None
 
         # Spectrogram extractor
-        self.spectrogram_extractor = Spectrogram(n_fft=window_size, hop_length=hop_size, 
-            win_length=window_size, window=window, center=center, pad_mode=pad_mode, 
-            freeze_parameters=True)
+        self.spectrogram_extractor = Spectrogram(
+            n_fft=window_size,
+            hop_length=hop_size,
+            win_length=window_size,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         # Logmel feature extractor
-        self.logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=window_size, 
-            n_mels=mel_bins, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db, 
-            freeze_parameters=True)
+        self.logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=window_size,
+            n_mels=mel_bins,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         # Spec augmenter
-        self.spec_augmenter = SpecAugmentation(time_drop_width=64, time_stripes_num=2, 
-            freq_drop_width=16, freq_stripes_num=2)
+        self.spec_augmenter = SpecAugmentation(
+            time_drop_width=64,
+            time_stripes_num=2,
+            freq_drop_width=16,
+            freq_stripes_num=2,
+        )
 
         self.bn0 = nn.BatchNorm2d(128)
 
@@ -2955,25 +3485,25 @@ class Cnn14_mel128(nn.Module):
 
         self.fc1 = nn.Linear(2048, 2048, bias=True)
         self.fc_audioset = nn.Linear(2048, classes_num, bias=True)
-        
+
         self.init_weight()
 
     def init_weight(self):
         init_bn(self.bn0)
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
 
-        x = self.spectrogram_extractor(input)   # (batch_size, 1, time_steps, freq_bins)
-        x = self.logmel_extractor(x)    # (batch_size, 1, time_steps, mel_bins)
-        
+        x = self.spectrogram_extractor(input)  # (batch_size, 1, time_steps, freq_bins)
+        x = self.logmel_extractor(x)  # (batch_size, 1, time_steps, mel_bins)
+
         x = x.transpose(1, 3)
         x = self.bn0(x)
         x = x.transpose(1, 3)
-        
+
         if self.training:
             x = self.spec_augmenter(x)
 
@@ -2981,20 +3511,20 @@ class Cnn14_mel128(nn.Module):
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
 
-        x = self.conv_block1(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block1(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block2(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block2(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block3(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block3(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block4(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block4(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block5(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block5(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block6(x, pool_size=(1, 1), pool_type='avg')
+        x = self.conv_block6(x, pool_size=(1, 1), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
         x = torch.mean(x, dim=3)
-        
+
         (x1, _) = torch.max(x, dim=2)
         x2 = torch.mean(x, dim=2)
         x = x1 + x2
@@ -3002,40 +3532,58 @@ class Cnn14_mel128(nn.Module):
         x = F.relu_(self.fc1(x))
         embedding = F.dropout(x, p=0.5, training=self.training)
         clipwise_output = torch.sigmoid(self.fc_audioset(x))
-        
-        output_dict = {'clipwise_output': clipwise_output, 'embedding': embedding}
+
+        output_dict = {"clipwise_output": clipwise_output, "embedding": embedding}
 
         return output_dict
 
 
 ############
 class Cnn14_DecisionLevelMax(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(Cnn14_DecisionLevelMax, self).__init__()
 
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
         ref = 1.0
         amin = 1e-10
         top_db = None
-        self.interpolate_ratio = 32     # Downsampled ratio
+        self.interpolate_ratio = 32  # Downsampled ratio
 
         # Spectrogram extractor
-        self.spectrogram_extractor = Spectrogram(n_fft=window_size, hop_length=hop_size, 
-            win_length=window_size, window=window, center=center, pad_mode=pad_mode, 
-            freeze_parameters=True)
+        self.spectrogram_extractor = Spectrogram(
+            n_fft=window_size,
+            hop_length=hop_size,
+            win_length=window_size,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         # Logmel feature extractor
-        self.logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=window_size, 
-            n_mels=mel_bins, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db, 
-            freeze_parameters=True)
+        self.logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=window_size,
+            n_mels=mel_bins,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         # Spec augmenter
-        self.spec_augmenter = SpecAugmentation(time_drop_width=64, time_stripes_num=2, 
-            freq_drop_width=8, freq_stripes_num=2)
+        self.spec_augmenter = SpecAugmentation(
+            time_drop_width=64,
+            time_stripes_num=2,
+            freq_drop_width=8,
+            freq_stripes_num=2,
+        )
 
         self.bn0 = nn.BatchNorm2d(64)
 
@@ -3048,27 +3596,27 @@ class Cnn14_DecisionLevelMax(nn.Module):
 
         self.fc1 = nn.Linear(2048, 2048, bias=True)
         self.fc_audioset = nn.Linear(2048, classes_num, bias=True)
-        
+
         self.init_weight()
 
     def init_weight(self):
         init_bn(self.bn0)
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
 
-        x = self.spectrogram_extractor(input)   # (batch_size, 1, time_steps, freq_bins)
-        x = self.logmel_extractor(x)    # (batch_size, 1, time_steps, mel_bins)
+        x = self.spectrogram_extractor(input)  # (batch_size, 1, time_steps, freq_bins)
+        x = self.logmel_extractor(x)  # (batch_size, 1, time_steps, mel_bins)
 
         frames_num = x.shape[2]
-        
+
         x = x.transpose(1, 3)
         x = self.bn0(x)
         x = x.transpose(1, 3)
-        
+
         if self.training:
             x = self.spec_augmenter(x)
 
@@ -3076,20 +3624,20 @@ class Cnn14_DecisionLevelMax(nn.Module):
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
 
-        x = self.conv_block1(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block1(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block2(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block2(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block3(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block3(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block4(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block4(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block5(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block5(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block6(x, pool_size=(1, 1), pool_type='avg')
+        x = self.conv_block6(x, pool_size=(1, 1), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
         x = torch.mean(x, dim=3)
-        
+
         x1 = F.max_pool1d(x, kernel_size=3, stride=1, padding=1)
         x2 = F.avg_pool1d(x, kernel_size=3, stride=1, padding=1)
         x = x1 + x2
@@ -3104,39 +3652,59 @@ class Cnn14_DecisionLevelMax(nn.Module):
         framewise_output = interpolate(segmentwise_output, self.interpolate_ratio)
         framewise_output = pad_framewise_output(framewise_output, frames_num)
 
-        output_dict = {'framewise_output': framewise_output, 
-            'clipwise_output': clipwise_output}
+        output_dict = {
+            "framewise_output": framewise_output,
+            "clipwise_output": clipwise_output,
+        }
 
         return output_dict
 
 
 class Cnn14_DecisionLevelAvg(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(Cnn14_DecisionLevelAvg, self).__init__()
 
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
         ref = 1.0
         amin = 1e-10
         top_db = None
-        self.interpolate_ratio = 32     # Downsampled ratio
+        self.interpolate_ratio = 32  # Downsampled ratio
 
         # Spectrogram extractor
-        self.spectrogram_extractor = Spectrogram(n_fft=window_size, hop_length=hop_size, 
-            win_length=window_size, window=window, center=center, pad_mode=pad_mode, 
-            freeze_parameters=True)
+        self.spectrogram_extractor = Spectrogram(
+            n_fft=window_size,
+            hop_length=hop_size,
+            win_length=window_size,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         # Logmel feature extractor
-        self.logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=window_size, 
-            n_mels=mel_bins, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db, 
-            freeze_parameters=True)
+        self.logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=window_size,
+            n_mels=mel_bins,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         # Spec augmenter
-        self.spec_augmenter = SpecAugmentation(time_drop_width=64, time_stripes_num=2, 
-            freq_drop_width=8, freq_stripes_num=2)
+        self.spec_augmenter = SpecAugmentation(
+            time_drop_width=64,
+            time_stripes_num=2,
+            freq_drop_width=8,
+            freq_stripes_num=2,
+        )
 
         self.bn0 = nn.BatchNorm2d(64)
 
@@ -3149,48 +3717,48 @@ class Cnn14_DecisionLevelAvg(nn.Module):
 
         self.fc1 = nn.Linear(2048, 2048, bias=True)
         self.fc_audioset = nn.Linear(2048, classes_num, bias=True)
-        
+
         self.init_weight()
 
     def init_weight(self):
         init_bn(self.bn0)
         init_layer(self.fc1)
         init_layer(self.fc_audioset)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
 
-        x = self.spectrogram_extractor(input)   # (batch_size, 1, time_steps, freq_bins)
-        x = self.logmel_extractor(x)    # (batch_size, 1, time_steps, mel_bins)
+        x = self.spectrogram_extractor(input)  # (batch_size, 1, time_steps, freq_bins)
+        x = self.logmel_extractor(x)  # (batch_size, 1, time_steps, mel_bins)
 
         frames_num = x.shape[2]
-        
+
         x = x.transpose(1, 3)
         x = self.bn0(x)
         x = x.transpose(1, 3)
-        
+
         if self.training:
             x = self.spec_augmenter(x)
 
         # Mixup on spectrogram
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
-        
-        x = self.conv_block1(x, pool_size=(2, 2), pool_type='avg')
+
+        x = self.conv_block1(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block2(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block2(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block3(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block3(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block4(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block4(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block5(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block5(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block6(x, pool_size=(1, 1), pool_type='avg')
+        x = self.conv_block6(x, pool_size=(1, 1), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
         x = torch.mean(x, dim=3)
-        
+
         x1 = F.max_pool1d(x, kernel_size=3, stride=1, padding=1)
         x2 = F.avg_pool1d(x, kernel_size=3, stride=1, padding=1)
         x = x1 + x2
@@ -3209,39 +3777,59 @@ class Cnn14_DecisionLevelAvg(nn.Module):
         framewise_output = interpolate(segmentwise_output, self.interpolate_ratio)
         framewise_output = pad_framewise_output(framewise_output, frames_num)
 
-        output_dict = {'framewise_output': framewise_output, 
-            'clipwise_output': clipwise_output}
+        output_dict = {
+            "framewise_output": framewise_output,
+            "clipwise_output": clipwise_output,
+        }
 
         return output_dict
 
 
 class Cnn14_DecisionLevelAtt(nn.Module):
-    def __init__(self, sample_rate, window_size, hop_size, mel_bins, fmin, 
-        fmax, classes_num):
-        
+    def __init__(
+        self, sample_rate, window_size, hop_size, mel_bins, fmin, fmax, classes_num
+    ):
         super(Cnn14_DecisionLevelAtt, self).__init__()
 
-        window = 'hann'
+        window = "hann"
         center = True
-        pad_mode = 'reflect'
+        pad_mode = "reflect"
         ref = 1.0
         amin = 1e-10
         top_db = None
-        self.interpolate_ratio = 32     # Downsampled ratio
+        self.interpolate_ratio = 32  # Downsampled ratio
 
         # Spectrogram extractor
-        self.spectrogram_extractor = Spectrogram(n_fft=window_size, hop_length=hop_size, 
-            win_length=window_size, window=window, center=center, pad_mode=pad_mode, 
-            freeze_parameters=True)
+        self.spectrogram_extractor = Spectrogram(
+            n_fft=window_size,
+            hop_length=hop_size,
+            win_length=window_size,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+            freeze_parameters=True,
+        )
 
         # Logmel feature extractor
-        self.logmel_extractor = LogmelFilterBank(sr=sample_rate, n_fft=window_size, 
-            n_mels=mel_bins, fmin=fmin, fmax=fmax, ref=ref, amin=amin, top_db=top_db, 
-            freeze_parameters=True)
+        self.logmel_extractor = LogmelFilterBank(
+            sr=sample_rate,
+            n_fft=window_size,
+            n_mels=mel_bins,
+            fmin=fmin,
+            fmax=fmax,
+            ref=ref,
+            amin=amin,
+            top_db=top_db,
+            freeze_parameters=True,
+        )
 
         # Spec augmenter
-        self.spec_augmenter = SpecAugmentation(time_drop_width=64, time_stripes_num=2, 
-            freq_drop_width=8, freq_stripes_num=2)
+        self.spec_augmenter = SpecAugmentation(
+            time_drop_width=64,
+            time_stripes_num=2,
+            freq_drop_width=8,
+            freq_stripes_num=2,
+        )
 
         self.bn0 = nn.BatchNorm2d(64)
 
@@ -3253,48 +3841,48 @@ class Cnn14_DecisionLevelAtt(nn.Module):
         self.conv_block6 = ConvBlock(in_channels=1024, out_channels=2048)
 
         self.fc1 = nn.Linear(2048, 2048, bias=True)
-        self.att_block = AttBlock(2048, classes_num, activation='sigmoid')
-        
+        self.att_block = AttBlock(2048, classes_num, activation="sigmoid")
+
         self.init_weight()
 
     def init_weight(self):
         init_bn(self.bn0)
         init_layer(self.fc1)
- 
+
     def forward(self, input, mixup_lambda=None):
         """
         Input: (batch_size, data_length)"""
 
-        x = self.spectrogram_extractor(input)   # (batch_size, 1, time_steps, freq_bins)
-        x = self.logmel_extractor(x)    # (batch_size, 1, time_steps, mel_bins)
+        x = self.spectrogram_extractor(input)  # (batch_size, 1, time_steps, freq_bins)
+        x = self.logmel_extractor(x)  # (batch_size, 1, time_steps, mel_bins)
 
         frames_num = x.shape[2]
-        
+
         x = x.transpose(1, 3)
         x = self.bn0(x)
         x = x.transpose(1, 3)
-        
+
         if self.training:
             x = self.spec_augmenter(x)
 
         # Mixup on spectrogram
         if self.training and mixup_lambda is not None:
             x = do_mixup(x, mixup_lambda)
-        
-        x = self.conv_block1(x, pool_size=(2, 2), pool_type='avg')
+
+        x = self.conv_block1(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block2(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block2(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block3(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block3(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block4(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block4(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block5(x, pool_size=(2, 2), pool_type='avg')
+        x = self.conv_block5(x, pool_size=(2, 2), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
-        x = self.conv_block6(x, pool_size=(1, 1), pool_type='avg')
+        x = self.conv_block6(x, pool_size=(1, 1), pool_type="avg")
         x = F.dropout(x, p=0.2, training=self.training)
         x = torch.mean(x, dim=3)
-        
+
         x1 = F.max_pool1d(x, kernel_size=3, stride=1, padding=1)
         x2 = F.avg_pool1d(x, kernel_size=3, stride=1, padding=1)
         x = x1 + x2
@@ -3310,7 +3898,9 @@ class Cnn14_DecisionLevelAtt(nn.Module):
         framewise_output = interpolate(segmentwise_output, self.interpolate_ratio)
         framewise_output = pad_framewise_output(framewise_output, frames_num)
 
-        output_dict = {'framewise_output': framewise_output, 
-            'clipwise_output': clipwise_output}
+        output_dict = {
+            "framewise_output": framewise_output,
+            "clipwise_output": clipwise_output,
+        }
 
         return output_dict


### PR DESCRIPTION
## Summary
- apply Ruff formatting and lint fixes across the pipeline modules and helpers
- use the public `config_verify_dependencies` helper in the orchestrator for dependency validation
- guard tests against missing optional dependencies and remove unused constants from the PANN wrappers to satisfy lint

## Testing
- ruff format .
- ruff check --fix .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dc5c769818832e91e3acf67e293f4f