### PR TITLE
Restore int8 compute defaults

### DIFF
--- a/src/diaremot/__init__.py
+++ b/src/diaremot/__init__.py
@@ -155,8 +155,9 @@ def get_transcriber(config: Optional[Dict[str, Any]] = None):
 
     AudioTranscriber, create_transcriber = _cached_modules["transcriber"]
 
-    # Force CPU-only configuration
-    cpu_config = {"device": "cpu", "compute_type": "float32", **(config or {})}
+    # Force CPU-only configuration and prefer int8 quantisation unless overridden
+    cpu_config = {"device": "cpu", **(config or {})}
+    cpu_config.setdefault("compute_type", "int8")
 
     # Default model selection: allow overriding via env var DIAREMOT_MODEL
     try:

--- a/src/diaremot/cli.py
+++ b/src/diaremot/cli.py
@@ -8,7 +8,7 @@ from functools import lru_cache
 from importlib import import_module
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 import typer
 
@@ -277,8 +277,11 @@ def asr_run(
         "faster-whisper-tiny.en", help="Whisper/Faster-Whisper model identifier."
     ),
     asr_backend: str = typer.Option("faster", help="ASR backend", show_default=True),
-    asr_compute_type: str = typer.Option(
-        "float32", help="CT2 compute type for faster-whisper."
+    asr_compute_type: Literal["float32", "int8", "int8_float16"] = typer.Option(
+        "int8",
+        help="CT2 compute type for faster-whisper.",
+        case_sensitive=False,
+        show_default=True,
     ),
     asr_cpu_threads: int = typer.Option(1, help="CPU threads for ASR backend."),
     language: Optional[str] = typer.Option(None, help="Override ASR language"),
@@ -470,8 +473,11 @@ def asr_resume(
         "faster-whisper-tiny.en", help="Whisper/Faster-Whisper model identifier."
     ),
     asr_backend: str = typer.Option("faster", help="ASR backend", show_default=True),
-    asr_compute_type: str = typer.Option(
-        "float32", help="CT2 compute type for faster-whisper."
+    asr_compute_type: Literal["float32", "int8", "int8_float16"] = typer.Option(
+        "int8",
+        help="CT2 compute type for faster-whisper.",
+        case_sensitive=False,
+        show_default=True,
     ),
     asr_cpu_threads: int = typer.Option(1, help="CPU threads for ASR backend."),
     language: Optional[str] = typer.Option(None, help="Override ASR language"),

--- a/src/diaremot/pipeline/cli_entry.py
+++ b/src/diaremot/pipeline/cli_entry.py
@@ -55,7 +55,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--asr-compute-type",
-        default="float32",
+        default="int8",
         choices=["float32", "int8", "int8_float16"],
         help="Compute precision for ASR backend",
     )

--- a/src/diaremot/pipeline/config.py
+++ b/src/diaremot/pipeline/config.py
@@ -51,7 +51,7 @@ class PipelineConfig:
     speaker_limit: int | None = None
     whisper_model: str = "faster-whisper-tiny.en"
     asr_backend: str = "faster"
-    compute_type: str = "float32"
+    compute_type: str = "int8"
     cpu_threads: int = 1
     language: str | None = None
     language_mode: str = "auto"

--- a/src/diaremot/pipeline/diagnostics_smoke.py
+++ b/src/diaremot/pipeline/diagnostics_smoke.py
@@ -35,7 +35,7 @@ SMOKE_TEST_PIPELINE_OVERRIDES: Dict[str, Any] = {
 
 SMOKE_TEST_TRANSCRIBE_KWARGS: Dict[str, Any] = {
     "model_size": "faster-whisper-tiny.en",
-    "compute_type": "float32",
+    "compute_type": "int8",
     "beam_size": 1,
     "temperature": 0.0,
     "no_speech_threshold": 0.6,

--- a/src/diaremot/pipeline/pipeline_config.py
+++ b/src/diaremot/pipeline/pipeline_config.py
@@ -14,7 +14,7 @@ DEFAULT_PIPELINE_CONFIG: dict[str, Any] = {
     "speaker_limit": None,
     "whisper_model": "faster-whisper-tiny.en",
     "asr_backend": "faster",
-    "compute_type": "float32",
+    "compute_type": "int8",
     "cpu_threads": 1,
     "language": None,
     "language_mode": "auto",

--- a/src/diaremot/pipeline/validate_system_complete.py
+++ b/src/diaremot/pipeline/validate_system_complete.py
@@ -32,7 +32,7 @@ def set_cpu_environment():
     os.environ["CUDA_VISIBLE_DEVICES"] = ""
     os.environ["TORCH_DEVICE"] = "cpu"
     os.environ["WHISPER_DEVICE"] = "cpu"
-    os.environ["WHISPER_COMPUTE_TYPE"] = "float32"
+    os.environ["WHISPER_COMPUTE_TYPE"] = "int8"
     print("✓ CPU-only environment configured")
 
 


### PR DESCRIPTION
## Summary
- Restore the DiaRemot pipeline default ASR compute type to int8 across runtime config, CLI entry points, diagnostics, and validation helpers
- Ensure the package-level `get_transcriber` CPU fallback respects caller overrides while defaulting to int8 quantisation

## Testing
- bash ./setup.sh
- bash ./maint-codex.sh *(fails: repository has existing Ruff lint issues in tmp_models.py and tests/test_stageguard.py)*
- pytest tests/test_pipeline_config_module.py tests/test_pipeline_cli_entry_module.py tests/test_cli.py


------
https://chatgpt.com/codex/tasks/task_e_68dd74ac4f58832ebd68dc701ab9c09a