### PR TITLE
Expand segment schema with SED context and pacing metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,10 @@ asr_logprob_avg,snr_db,snr_db_sed,
 wpm,duration_s,words,pause_ratio,
 vq_jitter_pct,vq_shimmer_db,vq_hnr_db,vq_cpps_db,voice_quality_hint
 ```
+
+`events_top3_json` carries the top-k AudioSet clusters detected globally or per
+segment (when available), `noise_tag` surfaces the dominant background class,
+and `snr_db_sed` converts the SED noise score into an approximate SNR value for
+triage. The CSV also exposes normalized segment duration, token counts, and the
+pause ratio derived from paralinguistics, keeping downstream consumers aligned
+with the contract.

--- a/src/diaremot/affect/paralinguistics.py
+++ b/src/diaremot/affect/paralinguistics.py
@@ -2607,6 +2607,7 @@ def extract(
                     "wpm": feats.get("wpm"),
                     "pause_count": feats.get("pause_count"),
                     "pause_time_s": feats.get("pause_total_sec"),
+                    "pause_ratio": feats.get("pause_ratio"),
                     "f0_mean_hz": feats.get("pitch_med_hz"),
                     "f0_std_hz": feats.get("pitch_iqr_hz"),
                     "loudness_rms": feats.get("loudness_dbfs_med"),

--- a/src/diaremot/pipeline/outputs.py
+++ b/src/diaremot/pipeline/outputs.py
@@ -25,12 +25,18 @@ SEGMENT_COLUMNS = [
     "text_emotions_full_json",
     "intent_top",
     "intent_top3_json",
+    "events_top3_json",
+    "noise_tag",
+    "asr_logprob_avg",
+    "snr_db",
+    "snr_db_sed",
+    "wpm",
+    "duration_s",
+    "words",
+    "pause_ratio",
     "low_confidence_ser",
     "vad_unstable",
     "affect_hint",
-    "asr_logprob_avg",
-    "snr_db",
-    "wpm",
     "pause_count",
     "pause_time_s",
     "f0_mean_hz",
@@ -73,14 +79,15 @@ def default_affect() -> dict[str, Any]:
 
 
 def ensure_segment_keys(seg: dict[str, Any]) -> dict[str, Any]:
+    defaults: dict[str, Any] = {
+        "events_top3_json": "[]",
+        "low_confidence_ser": False,
+        "vad_unstable": False,
+        "error_flags": "",
+    }
     for key in SEGMENT_COLUMNS:
         if key not in seg:
-            if key == "error_flags":
-                seg[key] = ""
-            elif key in {"low_confidence_ser", "vad_unstable"}:
-                seg[key] = False
-            else:
-                seg[key] = None
+            seg[key] = defaults.get(key, None)
     return seg
 
 

--- a/tests/test_pipeline_outputs_module.py
+++ b/tests/test_pipeline_outputs_module.py
@@ -19,6 +19,12 @@ def test_ensure_segment_keys_populates_defaults() -> None:
     ensure_segment_keys(seg)
     for key in SEGMENT_COLUMNS:
         assert key in seg
+    assert seg["events_top3_json"] == "[]"
+    assert seg["noise_tag"] is None
+    assert seg["snr_db_sed"] is None
+    assert seg["duration_s"] is None
+    assert seg["words"] is None
+    assert seg["pause_ratio"] is None
 
 
 def test_writers_produce_files(tmp_path) -> None:
@@ -30,6 +36,7 @@ def test_writers_produce_files(tmp_path) -> None:
             "speaker_id": "S1",
             "speaker_name": "Speaker 1",
             "text": "hello",
+            "events_top3_json": "[]",
         }
     ]
     ensure_segment_keys(segments[0])
@@ -42,7 +49,9 @@ def test_writers_produce_files(tmp_path) -> None:
     write_segments_jsonl(jsonl_path, segments)
     write_timeline_csv(timeline_path, segments)
 
-    assert "speaker_id" in csv_path.read_text(encoding="utf-8")
+    csv_header = csv_path.read_text(encoding="utf-8")
+    assert "speaker_id" in csv_header
+    assert "events_top3_json" in csv_header
     json_lines = jsonl_path.read_text(encoding="utf-8").strip().splitlines()
     assert json.loads(json_lines[0])["speaker_id"] == "S1"
     assert "speaker_id" in timeline_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- extend the segment output schema with SED context, duration/word metrics, and pause ratio defaults
- propagate transcription, paralinguistic, and background SED data when assembling per-segment payloads
- refresh documentation and writer tests to cover the richer manifest schema

## Testing
- pytest tests/test_pipeline_outputs_module.py
- python -m diaremot.cli asr run --input data/sample.wav --outdir tmp_smoke --profile fast --asr-compute-type int8 *(fails: ModuleNotFoundError: No module named 'resampy')*

------
https://chatgpt.com/codex/tasks/task_e_68dd74e0d164832eb981dc1b616a794b