### PR TITLE
Normalize overlap interruption aggregates

### DIFF
--- a/src/diaremot/pipeline/orchestrator.py
+++ b/src/diaremot/pipeline/orchestrator.py
@@ -628,7 +628,6 @@ class AudioAnalysisPipelineV2:
         state = PipelineState(input_audio_path=input_audio_path, out_dir=outp)
 
         try:
- codex/refactor-audio-processing-pipeline-structure
             for stage in PIPELINE_STAGES:
                 with StageGuard(self.corelog, self.stats, stage.name) as guard:
                     stage.runner(self, state, guard)


### PR DESCRIPTION
## Summary
- normalize the overlap stage output by mapping per-speaker data into the made/received/overlap_sec structure
- increment interruption receivers from the overlap module payload and store the results on pipeline state
- add a regression test covering the overlap stage mapping and clear stray text that broke orchestrator imports

## Testing
- pytest tests/test_pipeline_stages_module.py

------
https://chatgpt.com/codex/tasks/task_e_68dd877c8a88832e87b0197870d33468