### PR TITLE
Translate paralinguistics overlap output for speaker summaries

### DIFF
--- a/tests/test_pipeline_stages_module.py
+++ b/tests/test_pipeline_stages_module.py
@@ -175,6 +175,7 @@ def test_run_overlap_maps_interruptions(tmp_path, stub_pipeline):
             {"interrupter": "S1", "interrupted": "S2"},
             {"interrupter": "S1", "interrupted": "S2"},
             {"interrupter": "S2", "interrupted": "S1"},
+            {"interrupter": "S3", "interrupted": "S1"},
         ],
     }
 
@@ -200,6 +201,7 @@ def test_run_overlap_maps_interruptions(tmp_path, stub_pipeline):
         "overlap_ratio": 0.4,
     }
     assert state.per_speaker_interrupts == {
-        "S1": {"made": 2, "received": 1, "overlap_sec": 2.5},
+        "S1": {"made": 2, "received": 2, "overlap_sec": 2.5},
         "S2": {"made": 1, "received": 2, "overlap_sec": 1.5},
+        "S3": {"made": 1, "received": 0, "overlap_sec": 0.0},
     }


### PR DESCRIPTION
## Summary
- convert the paralinguistics overlap payload into the made/received/overlap_sec structure consumed by speaker summaries
- derive received counts (and fallback made counts) from interruption events so speaker aggregates stay consistent
- extend the pipeline stages test with a stub overlap payload that validates the stored per-speaker interruption stats

## Testing
- pytest tests/test_pipeline_stages_module.py

------
https://chatgpt.com/codex/tasks/task_e_68dd8d9f70ec832e8bacc9e9287ae04f