### PR TITLE
Map overlap interruptions into speaker summary structure

### DIFF
--- a/src/diaremot/pipeline/stages/__init__.py
+++ b/src/diaremot/pipeline/stages/__init__.py
@@ -1,0 +1,5 @@
+"""Pipeline stage utilities for summary and reporting generation."""
+
+from .summaries import SummariesState, run_overlap
+
+__all__ = ["SummariesState", "run_overlap"]

--- a/src/diaremot/pipeline/stages/summaries.py
+++ b/src/diaremot/pipeline/stages/summaries.py
@@ -1,0 +1,89 @@
+"""Helpers for summary-oriented pipeline stages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+
+@dataclass(slots=True)
+class SummariesState:
+    """Mutable container for summary stage intermediates."""
+
+    segments: List[Dict[str, Any]] = field(default_factory=list)
+    turns: List[Dict[str, Any]] = field(default_factory=list)
+    overlap_stats: Dict[str, Any] = field(default_factory=dict)
+    per_speaker_interrupts: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    speakers_summary: List[Dict[str, Any]] = field(default_factory=list)
+
+
+def _safe_float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def run_overlap(state: SummariesState, paralinguistics_module: Any) -> SummariesState:
+    """Populate overlap statistics using the paralinguistics helper."""
+
+    compute: Optional[Callable[[Iterable[Dict[str, Any]]], Dict[str, Any]]] = None
+    if paralinguistics_module is not None:
+        compute = getattr(paralinguistics_module, "compute_overlap_and_interruptions", None)
+
+    if not callable(compute):
+        state.overlap_stats = {"overlap_total_sec": 0.0, "overlap_ratio": 0.0}
+        state.per_speaker_interrupts = {}
+        return state
+
+    try:
+        payload = compute(state.turns or state.segments or []) or {}
+    except Exception:
+        state.overlap_stats = {"overlap_total_sec": 0.0, "overlap_ratio": 0.0}
+        state.per_speaker_interrupts = {}
+        return state
+
+    overlap_total = _safe_float(payload.get("overlap_total_sec"))
+    overlap_ratio = _safe_float(payload.get("overlap_ratio"))
+    state.overlap_stats = {
+        "overlap_total_sec": overlap_total,
+        "overlap_ratio": overlap_ratio,
+    }
+
+    per_speaker_raw = payload.get("by_speaker") or {}
+    per_speaker: Dict[str, Dict[str, Any]] = {}
+    for speaker_id, stats in per_speaker_raw.items():
+        if not isinstance(stats, dict):
+            continue
+        sid = str(speaker_id)
+        per_speaker[sid] = {
+            "made": _safe_int(stats.get("interruptions")),
+            "received": 0,
+            "overlap_sec": _safe_float(stats.get("overlap_sec")),
+        }
+
+    for entry in payload.get("interruptions") or []:
+        if not isinstance(entry, dict):
+            continue
+        interrupted = entry.get("interrupted")
+        if interrupted is None:
+            continue
+        sid = str(interrupted)
+        if sid not in per_speaker:
+            stats = per_speaker_raw.get(sid) if isinstance(per_speaker_raw, dict) else None
+            overlap_sec = _safe_float(stats.get("overlap_sec")) if isinstance(stats, dict) else 0.0
+            per_speaker[sid] = {"made": 0, "received": 0, "overlap_sec": overlap_sec}
+        per_speaker[sid]["received"] = per_speaker[sid].get("received", 0) + 1
+
+    state.per_speaker_interrupts = per_speaker
+    return state
+
+
+__all__ = ["SummariesState", "run_overlap"]

--- a/tests/test_pipeline_stages_module.py
+++ b/tests/test_pipeline_stages_module.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from diaremot.pipeline.stages import SummariesState, run_overlap
+
+
+def test_run_overlap_maps_per_speaker_interruptions() -> None:
+    state = SummariesState(
+        turns=[
+            {"start": 0.0, "end": 1.0, "speaker_id": "A"},
+            {"start": 0.5, "end": 1.5, "speaker_id": "B"},
+        ]
+    )
+
+    payload = {
+        "overlap_total_sec": 1.25,
+        "overlap_ratio": 0.5,
+        "by_speaker": {
+            "A": {"overlap_sec": 0.75, "interruptions": 2},
+            "B": {"overlap_sec": 0.5, "interruptions": 1},
+        },
+        "interruptions": [
+            {"interrupter": "A", "interrupted": "B"},
+            {"interrupter": "B", "interrupted": "C"},
+        ],
+    }
+
+    called = {}
+
+    def fake_compute(turns):
+        called["turns"] = turns
+        return payload
+
+    module = SimpleNamespace(compute_overlap_and_interruptions=fake_compute)
+
+    run_overlap(state, module)
+
+    assert called["turns"] == state.turns
+    assert state.overlap_stats == {
+        "overlap_total_sec": 1.25,
+        "overlap_ratio": 0.5,
+    }
+    assert state.per_speaker_interrupts == {
+        "A": {"made": 2, "received": 0, "overlap_sec": 0.75},
+        "B": {"made": 1, "received": 1, "overlap_sec": 0.5},
+        "C": {"made": 0, "received": 1, "overlap_sec": 0.0},
+    }


### PR DESCRIPTION
## Summary
- add a summaries stage helper package that exposes the overlap runner
- map per-speaker overlap/interruptions data into the structure expected by the speakers summary builder
- cover the overlap runner with a unit test that stubs the paralinguistics overlap helper

## Testing
- pytest tests/test_pipeline_stages_module.py

------
https://chatgpt.com/codex/tasks/task_e_68dd8235ad0c832e8358d89e5fc1cc84