### PR TITLE
Handle cache env ValueError for external paths

### DIFF
--- a/src/diaremot/pipeline/cache_env.py
+++ b/src/diaremot/pipeline/cache_env.py
@@ -2,59 +2,23 @@
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
+
+from . import runtime_env
 
 __all__ = ["configure_local_cache_env"]
 
 
-def _should_skip(existing: str, target_path: Path, cache_root: Path) -> bool:
-    """Return True if existing path already satisfies the cache requirement."""
-    try:
-        existing_path = Path(existing).resolve()
-    except (OSError, RuntimeError, ValueError):
-        return False
-
-    if existing_path == target_path:
-        return True
-    try:
-        # Python <3.9 doesn't have is_relative_to; emulate to preserve behaviour.
-        existing_path.relative_to(cache_root)
-        return True
-    except ValueError:
-        return False
+_CACHE_ROOT: Path | None = None
 
 
-def configure_local_cache_env() -> None:
-    """Ensure HuggingFace/Torch caches resolve inside the repo-local `.cache` dir."""
-    cache_root = (Path(__file__).resolve().parents[3] / ".cache").resolve()
-    cache_root.mkdir(parents=True, exist_ok=True)
+def configure_local_cache_env() -> Path:
+    """Delegate to :mod:`runtime_env`'s robust cache configuration helper."""
 
-    targets = {
-        "HF_HOME": cache_root / "hf",
-        "HUGGINGFACE_HUB_CACHE": cache_root / "hf",
-        "TRANSFORMERS_CACHE": cache_root / "transformers",
-        "TORCH_HOME": cache_root / "torch",
-        "XDG_CACHE_HOME": cache_root,
-    }
-
-    for env_name, target in targets.items():
-        target_path = target.resolve()
-        existing = os.environ.get(env_name)
-        if existing and _should_skip(existing, target_path, cache_root):
-            continue
-        target_path.mkdir(parents=True, exist_ok=True)
-        os.environ[env_name] = str(target_path)
+    global _CACHE_ROOT
+    cache_root = runtime_env.configure_local_cache_env()
+    _CACHE_ROOT = cache_root
+    return cache_root
 
 
-_configured = False
-
-
-def _configure_once() -> None:
-    global _configured
-    if not _configured:
-        configure_local_cache_env()
-        _configured = True
-
-
-_configure_once()
+_CACHE_ROOT = configure_local_cache_env()

--- a/src/diaremot/pipeline/runtime_env.py
+++ b/src/diaremot/pipeline/runtime_env.py
@@ -9,6 +9,7 @@ from typing import Iterable
 __all__ = [
     "WINDOWS_MODELS_ROOT",
     "DEFAULT_WHISPER_MODEL",
+    "CACHE_ROOT",
     "configure_local_cache_env",
     "resolve_default_whisper_model",
 ]
@@ -60,9 +61,13 @@ def _ensure_writable_directory(path: Path) -> bool:
     return os.access(path, os.W_OK | os.X_OK)
 
 
-def configure_local_cache_env() -> None:
+CACHE_ROOT: Path | None = None
+
+
+def configure_local_cache_env() -> Path:
     """Ensure all cache directories resolve to a writable, local cache root."""
 
+    global CACHE_ROOT
     cache_root = None
     for candidate in _candidate_cache_roots(Path(__file__).resolve()):
         resolved = candidate.resolve()
@@ -93,6 +98,9 @@ def configure_local_cache_env() -> None:
                 try:
                     if existing_path.is_relative_to(cache_root):
                         continue
+                except ValueError:
+                    # Raised on Windows when paths reside on different drives.
+                    pass
                 except AttributeError:
                     # Python < 3.9 compatibility – fall back to manual check
                     try:
@@ -103,8 +111,11 @@ def configure_local_cache_env() -> None:
         target_path.mkdir(parents=True, exist_ok=True)
         os.environ[env_name] = str(target_path)
 
+    CACHE_ROOT = cache_root
+    return cache_root
 
-configure_local_cache_env()
+
+CACHE_ROOT = configure_local_cache_env()
 
 WINDOWS_MODELS_ROOT = Path("D:/models") if os.name == "nt" else None
 

--- a/tests/test_runtime_env.py
+++ b/tests/test_runtime_env.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from diaremot.pipeline import runtime_env
+from diaremot.pipeline import cache_env, runtime_env
 
 
 def test_configure_local_cache_env_site_packages(monkeypatch, tmp_path):
@@ -63,3 +63,100 @@ def test_configure_local_cache_env_site_packages(monkeypatch, tmp_path):
         target_value = Path(runtime_env.os.environ[env_name]).resolve()
         expected_path = expected_root if subdir is None else (expected_root / subdir).resolve()
         assert target_value == expected_path
+
+
+def test_cache_env_import_handles_readonly_prefix(monkeypatch, tmp_path):
+    """Pipeline cache helper should fall back when interpreter prefix is read-only."""
+
+    for name in (
+        "HF_HOME",
+        "HUGGINGFACE_HUB_CACHE",
+        "TRANSFORMERS_CACHE",
+        "TORCH_HOME",
+        "XDG_CACHE_HOME",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    fake_prefix = tmp_path / "prefix" / "lib" / "python3.11"
+    fake_site_packages = fake_prefix / "site-packages" / "diaremot" / "pipeline"
+    fake_site_packages.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(runtime_env, "__file__", str(fake_site_packages / "runtime_env.py"))
+    monkeypatch.setattr(cache_env, "__file__", str(fake_site_packages / "cache_env.py"))
+
+    monkeypatch.chdir(fake_prefix)
+
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home_dir)
+
+    blocked_prefix = fake_prefix.resolve()
+    original_mkdir = Path.mkdir
+
+    def guarded_mkdir(self, mode=0o777, parents=False, exist_ok=False):  # type: ignore[override]
+        resolved = Path(self).resolve()
+        if str(resolved).startswith(str(blocked_prefix)):
+            raise PermissionError("interpreter prefix is read-only")
+        return original_mkdir(self, mode=mode, parents=parents, exist_ok=exist_ok)
+
+    monkeypatch.setattr(Path, "mkdir", guarded_mkdir)
+
+    cache_root = cache_env.configure_local_cache_env()
+
+    expected_root = (home_dir / ".cache" / "diaremot").resolve()
+    assert cache_root == expected_root
+    assert expected_root.exists()
+
+    for env_name, subdir in {
+        "HF_HOME": "hf",
+        "HUGGINGFACE_HUB_CACHE": "hf",
+        "TRANSFORMERS_CACHE": "transformers",
+        "TORCH_HOME": "torch",
+        "XDG_CACHE_HOME": None,
+    }.items():
+        value = Path(runtime_env.os.environ[env_name]).resolve()
+        expected_path = expected_root if subdir is None else (expected_root / subdir).resolve()
+        assert value == expected_path
+
+
+def test_configure_local_cache_env_overrides_external_env(monkeypatch, tmp_path):
+    """Existing cache env vars on other drives should be overridden without crashing."""
+
+    for name in (
+        "HF_HOME",
+        "HUGGINGFACE_HUB_CACHE",
+        "TRANSFORMERS_CACHE",
+        "TORCH_HOME",
+        "XDG_CACHE_HOME",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    project_root = tmp_path / "project"
+    module_path = project_root / "src" / "diaremot" / "pipeline"
+    module_path.mkdir(parents=True, exist_ok=True)
+    (project_root / "pyproject.toml").touch()
+    monkeypatch.setattr(runtime_env, "__file__", str(module_path / "runtime_env.py"))
+
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home_dir)
+
+    expected_root = (project_root / ".cache").resolve()
+
+    external_root = tmp_path / "external_cache"
+    (external_root / "hf").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HF_HOME", str((external_root / "hf").resolve()))
+
+    original_is_relative_to = Path.is_relative_to
+
+    def raising_is_relative_to(self, other):  # type: ignore[override]
+        if self == (external_root / "hf").resolve() and other == expected_root:
+            raise ValueError("different drives")
+        return original_is_relative_to(self, other)
+
+    monkeypatch.setattr(Path, "is_relative_to", raising_is_relative_to)
+
+    cache_root = runtime_env.configure_local_cache_env()
+
+    assert cache_root == expected_root
+    assert Path(runtime_env.os.environ["HF_HOME"]).resolve() == (expected_root / "hf").resolve()


### PR DESCRIPTION
## Summary
- guard cache root detection against ValueError when existing env paths live on other drives
- extend runtime environment tests to cover external cache variables that trigger is_relative_to errors

## Testing
- pytest tests/test_runtime_env.py

------
https://chatgpt.com/codex/tasks/task_e_68dd91e2d57c832ebdb94686bff2e5e5