### PR TITLE
Add __main__ guards to audio pipeline core shims

### DIFF
--- a/audio_pipeline_core.py
+++ b/audio_pipeline_core.py
@@ -7,7 +7,14 @@ root continue to function. The real implementation lives under ``src/``.
 
 from __future__ import annotations
 
+import sys
+
 import diaremot.pipeline.audio_pipeline_core as _core
+from diaremot.pipeline import cli_entry as _cli_entry
 from diaremot.pipeline.audio_pipeline_core import *  # noqa: F401,F403
 
 __all__ = getattr(_core, "__all__", [])
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via explicit tests
+    sys.exit(_cli_entry.main(sys.argv[1:]))

--- a/src/diaremot/pipeline/audio_pipeline_core.py
+++ b/src/diaremot/pipeline/audio_pipeline_core.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import sys
+
+from . import cli_entry
 from .cli_entry import _args_to_config, _build_arg_parser, main
 from .config import (
     CORE_DEPENDENCY_REQUIREMENTS,
@@ -65,3 +68,7 @@ __all__ = [
     "write_speakers_summary",
     "write_timeline_csv",
 ]
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via explicit tests
+    sys.exit(cli_entry.main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- add `__main__` guards to both audio pipeline core shims so they forward CLI invocations to `cli_entry.main`
- expand tests to ensure both module entrypoints hand off arguments correctly when run as scripts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dd94c03b50832eb4ac33adf1c867d3