### PR TITLE
Enforce SED stage as required default

### DIFF
--- a/src/diaremot/affect/sed_panns.py
+++ b/src/diaremot/affect/sed_panns.py
@@ -32,14 +32,14 @@ else:
 
 logger = logging.getLogger(__name__)
 
-try:  # pragma: no cover - optional dependency
+try:  # pragma: no cover - auxiliary dependency
     import librosa  # type: ignore[import-not-found]
 
     _HAVE_LIBROSA = True
 except Exception:  # pragma: no cover - env dependent
     _HAVE_LIBROSA = False
 
-try:  # pragma: no cover - optional dependency detection
+try:  # pragma: no cover - dependency detection
     import importlib.util as _ort_util  # type: ignore[import-not-found]
 
     _HAVE_ORT = _ort_util.find_spec("onnxruntime") is not None
@@ -86,7 +86,7 @@ EvalStrategy = Literal["head", "uniform"]
 
 @dataclass
 class SEDConfig:
-    """Configuration for optional sound event detection."""
+    """Configuration for the sound event detection stage."""
 
     top_k: int = 3
     run_on_suspect_only: bool = True

--- a/src/diaremot/pipeline/logging_utils.py
+++ b/src/diaremot/pipeline/logging_utils.py
@@ -128,12 +128,6 @@ def _fmt_hms_ms(milliseconds: float) -> str:
 
 class StageGuard(AbstractContextManager["StageGuard"]):
     _OPTIONAL_STAGE_EXCEPTION_MAP = {
-        "background_sed": (
-            ImportError,
-            ModuleNotFoundError,
-            FileNotFoundError,
-            OSError,
-        ),
         "registry_update": (
             FileNotFoundError,
             PermissionError,
@@ -245,7 +239,7 @@ class StageGuard(AbstractContextManager["StageGuard"]):
                     if stage == "affect_and_assemble":
                         return "Install emotion/intent model dependencies or run with --disable_affect."
                     if stage == "background_sed":
-                        return "Provide SED models locally or disable background SED tagging."
+                        return "Install and configure SED dependencies; this stage is required."
                     if stage == "overlap_interruptions":
                         return "Install paralinguistics extras for overlap metrics or skip this stage."
                     if stage == "conversation_analysis":

--- a/src/diaremot/pipeline/orchestrator.py
+++ b/src/diaremot/pipeline/orchestrator.py
@@ -384,12 +384,17 @@ class AudioAnalysisPipelineV2:
                     intent_labels=cfg.get("intent_labels", INTENT_LABELS_DEFAULT),
                 )
 
-            # Optional background SED / noise tagger
+            # Background SED / noise tagger (required in the default pipeline)
             self.sed_tagger = None
             try:
-                if PANNSEventTagger is not None and bool(cfg.get("enable_sed", True)):
+                sed_enabled = bool(cfg.get("enable_sed", True))
+                if PANNSEventTagger is not None and sed_enabled:
                     self.sed_tagger = PANNSEventTagger(
                         SEDConfig() if SEDConfig else None
+                    )
+                elif not sed_enabled:
+                    self.corelog.warn(
+                        "[sed] disabled via configuration; pipeline outputs will lack background tags"
                     )
             except Exception:
                 self.sed_tagger = None

--- a/src/diaremot/pipeline/stages/preprocess.py
+++ b/src/diaremot/pipeline/stages/preprocess.py
@@ -1,4 +1,4 @@
-"""Preprocessing stages (audio + optional background SED)."""
+"""Preprocessing stages (audio + background SED tagging)."""
 
 from __future__ import annotations
 
@@ -144,7 +144,7 @@ def run_background_sed(
     ) as exc:
         pipeline.corelog.warn(
             "[sed] tagging skipped: "
-            f"{exc}. Install sed_panns dependencies or disable background SED."
+            f"{exc}. Install sed_panns dependencies; background SED is required."
         )
     finally:
         guard.done()


### PR DESCRIPTION
## Summary
- treat the background sound event detection stage as required by default and adjust preprocessing warnings accordingly
- update the pipeline orchestrator to warn when SED is disabled and keep StageGuard suggestions aligned with required dependencies
- refresh the SED configuration docs and dependency comments to remove "optional" wording

## Testing
- pytest tests/test_stageguard.py

------
https://chatgpt.com/codex/tasks/task_e_68dda0fb602c832e84f9947a8fe23ede