### PR TITLE
Prefer local ONNX intent classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Outputs:
 - **Tone (V/A/D)**: `audeering/wav2vec2-large-robust-12-ft-emotion-msp-dim`.
 - **Speech emotion (8‑class)**: `Dpngtm/wav2vec2-emotion-recognition`.
 - **Text emotions (28)**: `SamLowe/roberta-base-go_emotions` (full distribution; keep top‑5).
-- **Intent**: `facebook/bart-large-mnli` (zero‑shot over fixed intents).
+- **Intent**: Prefers local ONNX exports (e.g., `model_uint8.onnx` under `affect_intent_model_dir` such as `D:\\diaremot\\diaremot2-1\\models\\bart\\`) and falls back to the `facebook/bart-large-mnli` Hugging Face pipeline when no ONNX asset is available.
 - **SED**: PANNs CNN14 (ONNX) on onnxruntime; 1.0s frames, 0.5s hop; median filter 3–5; hysteresis 0.50/0.35; `min_dur=0.30s`; `merge_gap≤0.20s`; collapse AudioSet→~20 labels.
 - **Paralinguistics (REQUIRED)**: **Praat‑Parselmouth** for jitter/shimmer/HNR/CPPS + prosody (WPM/pauses).
 

--- a/src/diaremot/affect/emotion_analyzer.py
+++ b/src/diaremot/affect/emotion_analyzer.py
@@ -46,6 +46,9 @@ if not logger.handlers:
 logger.setLevel(logging.INFO)
 
 
+INTENT_HYPOTHESIS_TEMPLATE = "This example is about {}."
+
+
 # --------------------------
 # Label spaces / constants
 # --------------------------
@@ -291,6 +294,9 @@ class EmotionIntentAnalyzer:
         self._text_session = None  # ONNX runtime session
         self._text_tokenizer = None
         self._intent_pipeline = None
+        self._intent_session = None
+        self._intent_tokenizer = None
+        self._intent_entail_idx = 2
         self.affect_backend = backend
         self.affect_text_model_dir = affect_text_model_dir
         self.affect_intent_model_dir = affect_intent_model_dir
@@ -847,7 +853,82 @@ class EmotionIntentAnalyzer:
         return dist
 
     # -------- Intent (zero-shot or rule-based) --------
+    @staticmethod
+    def _intent_onnx_candidates(model_dir: str | Path) -> List[str | Path]:
+        base = Path(model_dir)
+        names = ("model_uint8.onnx", "model_int8.onnx", "model.onnx")
+        candidates: List[str | Path] = []
+        if base.exists():
+            for name in names:
+                candidate = base / name
+                if candidate.exists():
+                    candidates.append(candidate)
+            if not candidates:
+                candidates.append(base / names[0])
+            return candidates
+
+        base_str = str(model_dir).rstrip("/\\")
+        if not base_str:
+            return []
+        if base_str.startswith("hf://"):
+            prefix = base_str
+        else:
+            prefix = f"hf://{base_str}"
+        for name in names:
+            candidates.append(f"{prefix}/{name}")
+        return candidates
+
     def _lazy_intent(self):
+        if self.affect_backend == "onnx":
+            if (
+                self._intent_session is not None
+                and self._intent_tokenizer is not None
+                and self._intent_entail_idx is not None
+            ):
+                return
+            model_name = self.affect_intent_model_dir or self.intent_model_name
+            try:
+                from transformers import AutoConfig, AutoTokenizer
+
+                tokenizer = AutoTokenizer.from_pretrained(model_name)
+                config = AutoConfig.from_pretrained(model_name)
+                label2id = {
+                    str(k).lower(): int(v)
+                    for k, v in getattr(config, "label2id", {}).items()
+                }
+                entail_idx = label2id.get("entailment", 2)
+                if entail_idx is None:
+                    entail_idx = 2
+
+                model_path: Optional[Path] = None
+                last_error: Optional[Exception] = None
+                for ident in self._intent_onnx_candidates(model_name):
+                    try:
+                        candidate_path = ensure_onnx_model(ident)
+                    except Exception as exc:
+                        last_error = exc
+                        continue
+                    if Path(candidate_path).exists():
+                        model_path = Path(candidate_path)
+                        break
+                if model_path is None:
+                    if last_error is not None:
+                        raise last_error
+                    raise FileNotFoundError("No ONNX intent model found")
+
+                session = create_onnx_session(model_path)
+                self._intent_tokenizer = tokenizer
+                self._intent_session = session
+                self._intent_entail_idx = entail_idx
+                self._intent_pipeline = None
+                return
+            except Exception as e:
+                logger.warning(
+                    f"Intent ONNX model unavailable ({e}); falling back to transformer pipeline"
+                )
+                self._intent_session = None
+                self._intent_tokenizer = None
+
         if self._intent_pipeline is not None:
             return
         model_name = self.affect_intent_model_dir or self.intent_model_name
@@ -860,10 +941,6 @@ class EmotionIntentAnalyzer:
                 tokenizer=model_name,
             )
         except Exception as e:
-            if self.affect_backend == "onnx":
-                logger.info(
-                    "Intent ONNX backend not implemented; using transformer pipeline fallback"
-                )
             logger.warning(f"Intent model unavailable ({e}); will use fallback")
             self._intent_pipeline = None
 
@@ -871,6 +948,79 @@ class EmotionIntentAnalyzer:
         t = (text or "").strip()
         self._lazy_intent()
         try:
+            if (
+                self._intent_session is not None
+                and self._intent_tokenizer is not None
+                and t
+            ):
+                hypotheses = [
+                    INTENT_HYPOTHESIS_TEMPLATE.format(label)
+                    for label in self.intent_labels
+                ]
+                if not hypotheses:
+                    raise RuntimeError("no intent labels configured")
+                enc = self._intent_tokenizer(
+                    [t] * len(hypotheses),
+                    hypotheses,
+                    return_tensors="np",
+                    padding=True,
+                    truncation=True,
+                )
+                ort_inputs = {k: v for k, v in enc.items()}
+                outputs = self._intent_session.run(None, ort_inputs)
+                if not outputs:
+                    raise RuntimeError("intent session returned no outputs")
+                raw_logits = outputs[0]
+                use_stub_np = bool(getattr(np, "__stub__", False))
+                entail_idx = int(self._intent_entail_idx or 2)
+
+                if use_stub_np:
+                    if isinstance(raw_logits, list):
+                        if raw_logits and isinstance(raw_logits[0], (list, tuple)):
+                            rows = [list(map(float, row)) for row in raw_logits]
+                        else:
+                            rows = [list(map(float, raw_logits))]
+                    else:
+                        rows = [[float(raw_logits)]]
+
+                    probs_matrix: List[List[float]] = []
+                    for row in rows:
+                        if not row:
+                            probs_matrix.append([1.0])
+                            continue
+                        max_val = max(row)
+                        exps = [math.exp(val - max_val) for val in row]
+                        denom_val = sum(exps) or 1.0
+                        probs_matrix.append([val / denom_val for val in exps])
+                    entail_probs = [
+                        row[max(0, min(len(row) - 1, entail_idx))]
+                        for row in probs_matrix
+                    ]
+                else:
+                    logits = np.array(raw_logits)
+                    if logits.ndim == 1:
+                        logits = logits.reshape(1, -1)
+                    elif logits.ndim > 2:
+                        logits = logits.reshape(logits.shape[0], -1)
+                    entail_idx = max(0, min(logits.shape[-1] - 1, entail_idx))
+                    exp_logits = np.exp(
+                        logits - np.max(logits, axis=-1, keepdims=True)
+                    )
+                    denom = exp_logits.sum(axis=-1, keepdims=True)
+                    denom[denom == 0.0] = 1.0
+                    probs_arr = exp_logits / denom
+                    entail_probs = probs_arr[:, entail_idx].tolist()
+
+                dist = {
+                    lbl: float(entail_probs[i])
+                    for i, lbl in enumerate(self.intent_labels)
+                    if i < len(entail_probs)
+                }
+                dist = _normalize_scores(dist)
+                top = max(dist, key=dist.get)
+                top3 = _topk_distribution(dist, 3)
+                return top, top3
+
             if self._intent_pipeline is None or not t:
                 raise RuntimeError("intent pipeline missing or text empty")
             res = self._intent_pipeline(
@@ -1052,3 +1202,4 @@ def analyze_segment_batch(
 if __name__ == "__main__":
     # Smoke test (no model downloads here)
     print("updated_emotion_analyzer.py ready (CPU-only).")
+

--- a/tests/test_intent_onnx.py
+++ b/tests/test_intent_onnx.py
@@ -1,0 +1,138 @@
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SRC_ROOT = PROJECT_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+
+class _DummyTokenizer:
+    @classmethod
+    def from_pretrained(cls, model_dir):
+        return cls()
+
+    def __call__(
+        self,
+        texts,
+        hypotheses,
+        *,
+        return_tensors="np",
+        padding=False,
+        truncation=False,
+    ):
+        batch = len(hypotheses)
+        seq_len = 4
+        input_ids = [[0.0] * seq_len for _ in range(batch)]
+        attention_mask = [[1.0] * seq_len for _ in range(batch)]
+        return {"input_ids": input_ids, "attention_mask": attention_mask}
+
+
+class _DummyConfig:
+    label2id = {"contradiction": 0, "neutral": 1, "entailment": 2}
+
+    @classmethod
+    def from_pretrained(cls, model_dir):
+        return cls()
+
+
+def _install_transformers_stub():
+    module = types.ModuleType("transformers")
+    module.AutoTokenizer = _DummyTokenizer
+    module.AutoConfig = _DummyConfig
+
+    def _pipeline(*args, **kwargs):
+        class _Pipe:
+            def __call__(self, text, candidate_labels, multi_label=False):
+                scores = [1.0 / max(1, len(candidate_labels))] * len(candidate_labels)
+                return {"labels": list(candidate_labels), "scores": scores}
+
+        return _Pipe()
+
+    module.pipeline = _pipeline
+    sys.modules["transformers"] = module
+
+
+def test_intent_onnx_prefers_local_uint8(tmp_path, monkeypatch):
+    _install_transformers_stub()
+
+    from diaremot.affect import emotion_analyzer
+
+    model_dir = tmp_path / "bart"
+    model_dir.mkdir()
+    preferred = model_dir / "model_uint8.onnx"
+    preferred.write_bytes(b"onnx")
+
+    captured = {}
+
+    def _fake_ensure(path_like):
+        candidate = Path(path_like)
+        if not candidate.exists():
+            raise FileNotFoundError(candidate)
+        return candidate
+
+    def _fake_session(path, **kwargs):
+        captured["path"] = Path(path)
+
+        class _Session:
+            def run(self, *_args):
+                batch = 3
+                logits = np.array(
+                    [
+                        [6.0, 0.0, 8.0],
+                        [0.0, 0.0, 1.0],
+                        [0.0, 0.0, 0.5],
+                    ],
+                    dtype=np.float32,
+                )
+                return [logits]
+
+        return _Session()
+
+    monkeypatch.setattr(emotion_analyzer, "ensure_onnx_model", _fake_ensure)
+    monkeypatch.setattr(emotion_analyzer, "create_onnx_session", _fake_session)
+
+    analyzer = emotion_analyzer.EmotionIntentAnalyzer(
+        affect_backend="onnx",
+        affect_intent_model_dir=str(model_dir),
+        intent_labels=["support", "sales", "other"],
+    )
+
+    assert analyzer.intent_labels == ["support", "sales", "other"]
+
+    def _raise_rules(self, text):
+        raise RuntimeError("intent rules should not run")
+
+    monkeypatch.setattr(
+        emotion_analyzer.EmotionIntentAnalyzer,
+        "_intent_rules",
+        _raise_rules,
+        raising=False,
+    )
+
+    top, top3 = analyzer._infer_intent("Need help with installation")
+
+    assert captured["path"] == preferred
+    assert top == "support"
+    assert top3[0]["label"] == top, top3
+    assert {entry["label"] for entry in top3} == {"support", "sales", "other"}
+
+
+def test_intent_pipeline_fallback_when_no_text(monkeypatch):
+    _install_transformers_stub()
+
+    from diaremot.affect import emotion_analyzer
+
+    analyzer = emotion_analyzer.EmotionIntentAnalyzer(affect_backend="onnx")
+
+    monkeypatch.setattr(emotion_analyzer, "create_onnx_session", lambda *args, **kwargs: None)
+    monkeypatch.setattr(emotion_analyzer, "ensure_onnx_model", lambda *args, **kwargs: Path("missing"))
+
+    top, top3 = analyzer._infer_intent("")
+
+    assert top in analyzer.intent_labels
+    assert len(top3) == min(3, len(analyzer.intent_labels))


### PR DESCRIPTION
## Summary
- prefer local ONNX exports for the BART intent classifier with quantified lookup helpers and fallback to the transformer pipeline only when required
- normalize ONNX inference outputs even when numpy stubs are active to keep zero-shot probabilities usable
- add regression coverage for the ONNX-first path and document the new model expectations in the README

## Testing
- pytest tests/test_intent_onnx.py tests/test_pipeline_config_module.py

------
https://chatgpt.com/codex/tasks/task_e_68ddc8fc15a0832e85429d792b3c87d4