### PR TITLE
Fix CoreLogger formatting args handling

### DIFF
--- a/src/diaremot/pipeline/logging_utils.py
+++ b/src/diaremot/pipeline/logging_utils.py
@@ -81,14 +81,20 @@ class CoreLogger:
         record.update(fields)
         self.jsonl.emit(record)
 
-    def info(self, message: str) -> None:
-        self.log.info(message)
+    def info(self, message: str, *args: Any, **kwargs: Any) -> None:
+        """Log an informational message forwarding formatting arguments."""
 
-    def warn(self, message: str) -> None:
-        self.log.warning(message)
+        self.log.info(message, *args, **kwargs)
 
-    def error(self, message: str) -> None:
-        self.log.error(message)
+    def warn(self, message: str, *args: Any, **kwargs: Any) -> None:
+        """Log a warning message forwarding formatting arguments."""
+
+        self.log.warning(message, *args, **kwargs)
+
+    def error(self, message: str, *args: Any, **kwargs: Any) -> None:
+        """Log an error message forwarding formatting arguments."""
+
+        self.log.error(message, *args, **kwargs)
 
 
 def _fmt_hms(seconds: float) -> str:

--- a/tests/test_pipeline_logging_utils_module.py
+++ b/tests/test_pipeline_logging_utils_module.py
@@ -38,7 +38,21 @@ def test_stageguard_swallows_optional_exceptions(tmp_path) -> None:
     logger = CoreLogger("run", tmp_path / "log.jsonl", console_level=logging.CRITICAL)
     stats = RunStats(run_id="run", file_id="file.wav")
 
-    with StageGuard(logger, stats, "background_sed"):
-        raise ImportError("sed models missing")
+    with StageGuard(logger, stats, "paralinguistics"):
+        raise ImportError("librosa missing")
 
-    assert any(f["stage"] == "background_sed" for f in stats.failures)
+    assert any(f["stage"] == "paralinguistics" for f in stats.failures)
+
+
+def test_corelogger_supports_format_args(tmp_path, caplog) -> None:
+    logger = CoreLogger("run", tmp_path / "log.jsonl", console_level=logging.DEBUG)
+
+    with caplog.at_level(logging.DEBUG, logger=logger.log.name):
+        logger.info("formatted %s %s", "message", 123)
+        logger.warn("warn %s", "here")
+        logger.error("error %s", "there")
+
+    rendered = [record.getMessage() for record in caplog.records]
+    assert "formatted message 123" in rendered
+    assert "warn here" in rendered
+    assert "error there" in rendered


### PR DESCRIPTION
## Summary
- allow CoreLogger info/warn/error wrappers to forward format-string arguments to the underlying logger
- cover the regression with a unit test exercising info/warn/error and align the optional StageGuard test with the documented stage list

## Testing
- pytest tests/test_pipeline_logging_utils_module.py

------
https://chatgpt.com/codex/tasks/task_e_68ddf251c684832ea6d28d034e470a29