### PR TITLE
Propagate affect analyzer overrides

### DIFF
--- a/src/diaremot/pipeline/config.py
+++ b/src/diaremot/pipeline/config.py
@@ -61,6 +61,7 @@ class PipelineConfig:
     affect_backend: str = "onnx"
     affect_text_model_dir: Path | None = None
     affect_intent_model_dir: Path | None = None
+    affect_analyzer_threads: int | None = None
     beam_size: int = 1
     temperature: float = 0.0
     no_speech_threshold: float = 0.50
@@ -117,6 +118,14 @@ class PipelineConfig:
             ):
                 raise ValueError("intent_labels must be an iterable of strings")
             self.intent_labels = [str(label) for label in self.intent_labels]
+
+        if self.affect_analyzer_threads is not None:
+            try:
+                threads = int(self.affect_analyzer_threads)
+            except (TypeError, ValueError) as exc:
+                raise ValueError("affect_analyzer_threads must be an integer > 0") from exc
+            self._validate_positive_int("affect_analyzer_threads", threads)
+            self.affect_analyzer_threads = threads
 
         self.affect_backend = self._lower_choice(
             "affect_backend", self.affect_backend, {"auto", "onnx", "torch"}

--- a/src/diaremot/pipeline/orchestrator.py
+++ b/src/diaremot/pipeline/orchestrator.py
@@ -374,6 +374,25 @@ class AudioAnalysisPipelineV2:
             self.tx = AudioTranscriber(**transcriber_config)
 
             # Affect analyzer (optional)
+            def _normalize_model_dir(value: Any) -> str | None:
+                if value in (None, ""):
+                    return None
+                try:
+                    return os.fspath(value)
+                except TypeError:
+                    return str(value)
+
+            affect_backend = cfg.get("affect_backend", "onnx")
+            if affect_backend is not None:
+                affect_backend = str(affect_backend)
+            affect_text_model_dir = _normalize_model_dir(
+                cfg.get("affect_text_model_dir")
+            )
+            affect_intent_model_dir = _normalize_model_dir(
+                cfg.get("affect_intent_model_dir")
+            )
+            affect_analyzer_threads = cfg.get("affect_analyzer_threads")
+
             if cfg.get("disable_affect"):
                 self.affect = None
             else:
@@ -382,6 +401,10 @@ class AudioAnalysisPipelineV2:
                         "text_emotion_model", "SamLowe/roberta-base-go_emotions"
                     ),
                     intent_labels=cfg.get("intent_labels", INTENT_LABELS_DEFAULT),
+                    affect_backend=affect_backend,
+                    affect_text_model_dir=affect_text_model_dir,
+                    affect_intent_model_dir=affect_intent_model_dir,
+                    analyzer_threads=affect_analyzer_threads,
                 )
 
             # Background SED / noise tagger (required in the default pipeline)
@@ -432,6 +455,14 @@ class AudioAnalysisPipelineV2:
                 "temperature": cfg.get("temperature", 0.0),
                 "no_speech_threshold": cfg.get("no_speech_threshold", 0.50),
                 "intent_labels": cfg.get("intent_labels", INTENT_LABELS_DEFAULT),
+                "affect_backend": affect_backend,
+                "affect_text_model_dir": affect_text_model_dir,
+                "affect_intent_model_dir": affect_intent_model_dir,
+                "affect_analyzer_threads": affect_analyzer_threads,
+                "text_emotion_model": cfg.get(
+                    "text_emotion_model", "SamLowe/roberta-base-go_emotions"
+                ),
+                "disable_affect": bool(cfg.get("disable_affect", False)),
             }
 
         except Exception as e:

--- a/src/diaremot/pipeline/pipeline_config.py
+++ b/src/diaremot/pipeline/pipeline_config.py
@@ -24,6 +24,7 @@ DEFAULT_PIPELINE_CONFIG: dict[str, Any] = {
     "affect_backend": "onnx",
     "affect_text_model_dir": None,
     "affect_intent_model_dir": None,
+    "affect_analyzer_threads": None,
     "beam_size": 1,
     "temperature": 0.0,
     "no_speech_threshold": 0.50,

--- a/tests/test_orchestrator_affect_overrides.py
+++ b/tests/test_orchestrator_affect_overrides.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from diaremot.pipeline import orchestrator as orchestrator_mod
+from diaremot.pipeline.orchestrator import AudioAnalysisPipelineV2, build_pipeline_config
+
+
+class _DummyComponent:
+    def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - simple stub
+        self.args = args
+        self.kwargs = kwargs
+
+
+class _DummyTranscriber:
+    def __init__(self, **kwargs) -> None:  # pragma: no cover - simple stub
+        self.kwargs = kwargs
+
+    def get_model_info(self) -> dict[str, object]:  # pragma: no cover - simple stub
+        return {}
+
+
+def test_affect_overrides_passed_to_analyzer(monkeypatch, tmp_path: Path) -> None:
+    captured: dict[str, object] = {}
+
+    class _RecordingAnalyzer:
+        def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - test helper
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(orchestrator_mod, "EmotionIntentAnalyzer", _RecordingAnalyzer)
+    monkeypatch.setattr(orchestrator_mod, "AudioPreprocessor", _DummyComponent)
+    monkeypatch.setattr(orchestrator_mod, "SpeakerDiarizer", _DummyComponent)
+    monkeypatch.setattr(orchestrator_mod, "HTMLSummaryGenerator", lambda: _DummyComponent())
+    monkeypatch.setattr(orchestrator_mod, "PDFSummaryGenerator", lambda: _DummyComponent())
+    monkeypatch.setattr(orchestrator_mod, "PANNSEventTagger", None)
+    monkeypatch.setattr(
+        "diaremot.pipeline.transcription_module.AudioTranscriber",
+        _DummyTranscriber,
+    )
+
+    text_dir = tmp_path / "custom_text"
+    intent_dir = tmp_path / "custom_intent"
+    text_dir.mkdir()
+    intent_dir.mkdir()
+
+    cfg = build_pipeline_config(
+        {
+            "affect_backend": "torch",
+            "affect_text_model_dir": text_dir,
+            "affect_intent_model_dir": intent_dir,
+            "affect_analyzer_threads": 3,
+            "log_dir": tmp_path / "logs",
+            "cache_root": tmp_path / "cache",
+            "checkpoint_dir": tmp_path / "checkpoints",
+        }
+    )
+
+    pipeline = AudioAnalysisPipelineV2(cfg)
+
+    assert "kwargs" in captured, "EmotionIntentAnalyzer was not initialised"
+    kwargs = captured["kwargs"]
+    assert kwargs["affect_backend"] == "torch"
+    assert kwargs["affect_text_model_dir"] == os.fspath(text_dir)
+    assert kwargs["affect_intent_model_dir"] == os.fspath(intent_dir)
+    assert kwargs["analyzer_threads"] == 3
+
+    snapshot = pipeline.stats.config_snapshot
+    assert snapshot["affect_backend"] == "torch"
+    assert snapshot["affect_text_model_dir"] == os.fspath(text_dir)
+    assert snapshot["affect_intent_model_dir"] == os.fspath(intent_dir)
+    assert snapshot["affect_analyzer_threads"] == 3

--- a/tests/test_pipeline_config_module.py
+++ b/tests/test_pipeline_config_module.py
@@ -48,6 +48,7 @@ def test_pipeline_config_normalises_path_and_choice_fields(tmp_path: Path) -> No
         affect_text_model_dir=str(tmp_path / "text"),
         affect_intent_model_dir=tmp_path / "intent",
         affect_backend="TORCH",
+        affect_analyzer_threads=4,
         asr_backend="Faster",
         vad_backend="AUTO",
         loudness_mode="BROADCAST",
@@ -62,6 +63,7 @@ def test_pipeline_config_normalises_path_and_choice_fields(tmp_path: Path) -> No
     assert cfg.affect_text_model_dir == tmp_path / "text"
     assert cfg.affect_intent_model_dir == tmp_path / "intent"
     assert cfg.affect_backend == "torch"
+    assert cfg.affect_analyzer_threads == 4
     assert cfg.asr_backend == "faster"
     assert cfg.vad_backend == "auto"
     assert cfg.loudness_mode == "broadcast"
@@ -78,3 +80,6 @@ def test_pipeline_config_rejects_invalid_formats() -> None:
 
     with pytest.raises(ValueError):
         PipelineConfig(cpu_threads=0)
+
+    with pytest.raises(ValueError):
+        PipelineConfig(affect_analyzer_threads=0)


### PR DESCRIPTION
## Summary
- extend the pipeline configuration to accept an affect analyzer thread override and expose it through the defaults
- pass affect backend and custom model directory overrides through to `EmotionIntentAnalyzer` and record them in the config snapshot
- cover the behaviour with orchestration and configuration unit tests

## Testing
- pytest tests/test_pipeline_config_module.py tests/test_orchestrator_affect_overrides.py


------
https://chatgpt.com/codex/tasks/task_e_68e1e9aa8114832e86aaad63d2979e24