### PR TITLE
Populate paralinguistic timing metrics in affect stage

### DIFF
--- a/src/diaremot/affect/paralinguistics.py
+++ b/src/diaremot/affect/paralinguistics.py
@@ -2517,10 +2517,14 @@ def extract(wav: np.ndarray, sr: int, segs: list[dict[str, Any]]) -> list[dict[s
             start = max(0.0, min(start, total))
             end = max(start, min(end, total))
             text = s.get("text") or ""
+            duration_s = max(0.0, end - start)
+            words = len(text.split())
             feats = compute_segment_features_v2(wav, sr, start, end, text, cfg)
             out.append(
                 {
                     "wpm": feats.get("wpm"),
+                    "duration_s": duration_s,
+                    "words": words,
                     "pause_count": feats.get("pause_count"),
                     "pause_time_s": feats.get("pause_total_sec"),
                     "pause_ratio": feats.get("pause_ratio"),

--- a/src/diaremot/pipeline/stages/affect.py
+++ b/src/diaremot/pipeline/stages/affect.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 from typing import Any
 
 import numpy as np
@@ -32,6 +33,20 @@ def run(pipeline: AudioAnalysisPipelineV2, state: PipelineState, guard: StageGua
 
         aff = pipeline._affect_unified(clip, state.sr, text)
         pm = state.para_metrics.get(idx, {})
+
+        duration_s = _coerce_positive_float(pm.get("duration_s"))
+        if duration_s is None:
+            duration_s = max(0.0, end - start)
+
+        words = _coerce_int(pm.get("words"))
+        if words is None:
+            words = len(text.split())
+
+        pause_ratio = _coerce_positive_float(pm.get("pause_ratio"))
+        if pause_ratio is None:
+            pause_time = _coerce_positive_float(pm.get("pause_time_s")) or 0.0
+            pause_ratio = (pause_time / duration_s) if duration_s > 0 else 0.0
+        pause_ratio = max(0.0, min(1.0, pause_ratio))
 
         vad = aff.get("vad", {})
         speech_emotion = aff.get("speech_emotion", {})
@@ -69,6 +84,9 @@ def run(pipeline: AudioAnalysisPipelineV2, state: PipelineState, guard: StageGua
             "asr_logprob_avg": seg.get("asr_logprob_avg"),
             "snr_db": seg.get("snr_db"),
             "wpm": pm.get("wpm", 0.0),
+            "duration_s": duration_s,
+            "words": words,
+            "pause_ratio": pause_ratio,
             "pause_count": pm.get("pause_count", 0),
             "pause_time_s": pm.get("pause_time_s", 0.0),
             "f0_mean_hz": pm.get("f0_mean_hz", 0.0),
@@ -86,3 +104,25 @@ def run(pipeline: AudioAnalysisPipelineV2, state: PipelineState, guard: StageGua
 
     state.segments_final = segments_final
     guard.done(segments=len(segments_final))
+
+
+def _coerce_positive_float(value: Any) -> float | None:
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(result) or result < 0:
+        return None
+    return result
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        try:
+            return int(float(value))
+        except (TypeError, ValueError):
+            return None

--- a/tests/test_pipeline_stages_module.py
+++ b/tests/test_pipeline_stages_module.py
@@ -1,5 +1,6 @@
 import types
 
+import math
 import numpy as np
 import pytest
 
@@ -7,6 +8,7 @@ from diaremot.pipeline.logging_utils import StageGuard
 from diaremot.pipeline.orchestrator import AudioAnalysisPipelineV2
 from diaremot.pipeline.outputs import default_affect
 from diaremot.pipeline.stages import PIPELINE_STAGES, PipelineState, dependency_check
+from diaremot.pipeline.stages.affect import run as run_affect_stage
 from diaremot.pipeline.stages.summaries import run_overlap
 
 
@@ -222,6 +224,67 @@ def test_stage_services_execute_full_cycle(tmp_path, monkeypatch, stub_pipeline)
     assert "auto_tune" in pipeline.stats.config_snapshot
     assert state.tuning_summary
     assert state.tuning_history
+
+
+def test_affect_stage_uses_paralinguistics_metrics(tmp_path, stub_pipeline):
+    pipeline = stub_pipeline
+
+    state = PipelineState(input_audio_path="dummy.wav", out_dir=tmp_path)
+    state.sr = 16000
+    state.y = np.zeros(int(3 * state.sr), dtype=np.float32)
+    state.norm_tx = [
+        {
+            "start": 1.0,
+            "end": 2.5,
+            "speaker_id": "S1",
+            "speaker_name": "Speaker_1",
+            "text": "alpha beta gamma delta epsilon",
+        }
+    ]
+    state.para_metrics = {
+        0: {
+            "wpm": 120.0,
+            "duration_s": 1.5,
+            "words": 5,
+            "pause_ratio": 0.25,
+            "pause_time_s": 0.375,
+        }
+    }
+
+    with StageGuard(pipeline.corelog, pipeline.stats, "affect_and_assemble") as guard:
+        run_affect_stage(pipeline, state, guard)
+
+    assert state.segments_final, "Affect stage must emit segments"
+    seg = state.segments_final[0]
+    assert math.isclose(seg["duration_s"], 1.5, rel_tol=1e-6)
+    assert seg["words"] == 5
+    assert math.isclose(seg["pause_ratio"], 0.25, rel_tol=1e-6)
+
+
+def test_affect_stage_computes_fallback_metrics(tmp_path, stub_pipeline):
+    pipeline = stub_pipeline
+
+    state = PipelineState(input_audio_path="dummy.wav", out_dir=tmp_path)
+    state.sr = 16000
+    state.y = np.zeros(int(5 * state.sr), dtype=np.float32)
+    state.norm_tx = [
+        {
+            "start": 0.5,
+            "end": 3.5,
+            "speaker_id": "S1",
+            "speaker_name": "Speaker_1",
+            "text": "fallback path validation",
+        }
+    ]
+    state.para_metrics = {}
+
+    with StageGuard(pipeline.corelog, pipeline.stats, "affect_and_assemble") as guard:
+        run_affect_stage(pipeline, state, guard)
+
+    seg = state.segments_final[0]
+    assert math.isclose(seg["duration_s"], 3.0, rel_tol=1e-6)
+    assert seg["words"] == 3
+    assert seg["pause_ratio"] == 0.0
 
 
 def test_run_overlap_maps_interruptions(tmp_path, stub_pipeline):


### PR DESCRIPTION
## Summary
- populate duration, word count, and pause ratio in the affect stage using paralinguistics output with a start/end fallback
- extend the orchestrator and paralinguistics extractor so primary and fallback paths supply the new metrics
- add stage-level tests covering both populated and fallback paralinguistic data flows

## Testing
- pytest tests/test_pipeline_stages_module.py::test_affect_stage_uses_paralinguistics_metrics tests/test_pipeline_stages_module.py::test_affect_stage_computes_fallback_metrics -vv


------
https://chatgpt.com/codex/tasks/task_e_68e20fb83bb4832e8e994b72168514e4