### PR TITLE
Align CLI docs with pipeline defaults and fix connector runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ Pipeline Architecture (unchanged)
 Contract (unchanged)
 - 11 stages must run by default; see `src/diaremot/pipeline/stages/__init__.py::PIPELINE_STAGES`
 - Segment CSV schema is 39 columns as defined in `src/diaremot/pipeline/outputs.py::SEGMENT_COLUMNS`
+- Paralinguistics stage must emit all 14 metrics: `wpm`, `duration_s`, `words`, `pause_count`, `pause_time_s`, `pause_ratio`, `f0_mean_hz`, `f0_std_hz`, `loudness_rms`, `disfluency_count`, `vq_jitter_pct`, `vq_shimmer_db`, `vq_hnr_db`, `vq_cpps_db`
 - ASR default compute type for main CLI is `float32`
 
 Models & Assets

--- a/AI_INDEX.yaml
+++ b/AI_INDEX.yaml
@@ -746,10 +746,10 @@ cli_reference:
         choices: [float32, int8, int8_float16]
         description: ASR inference precision
         
-      - flag: --asr-model
+      - flag: --whisper-model
         type: string
         default: tiny.en
-        description: faster-whisper model name
+        description: faster-whisper / Whisper model identifier
         
     diarization_overrides:
       note: These override orchestrator defaults
@@ -773,7 +773,7 @@ cli_reference:
         orchestrator_default: 0.80
         description: Minimum silence duration
         
-      - flag: --speech-pad-sec
+      - flag: --vad-speech-pad-sec
         type: float
         default: null
         orchestrator_default: 0.10

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,6 +281,7 @@ python -m diaremot.cli run --input <file> --outdir <dir> --asr-compute-type int8
 # Override orchestrator's VAD tuning
 python -m diaremot.cli run --input <file> --outdir <dir> \
   --vad-threshold 0.30 \
+  --vad-speech-pad-sec 0.20 \
   --ahc-distance-threshold 0.12
 ```
 
@@ -290,7 +291,7 @@ python -m diaremot.cli run --input <file> --outdir <dir> \
 - `--asr-compute-type` — `float32` (default) | `int8` | `int8_float16`
 - `--vad-threshold` — Override orchestrator default (0.35)
 - `--vad-min-speech-sec` — Override default (0.80)
-- `--speech-pad-sec` — Override orchestrator default (0.10)
+- `--vad-speech-pad-sec` — Override orchestrator default (0.10)
 - `--ahc-distance-threshold` — Override orchestrator default (0.15)
 - `--profile` — `default` | `fast` | `accurate` | `offline` | path to JSON
 - `--disable-sed` — Skip sound event detection
@@ -500,7 +501,7 @@ python -m diaremot.cli resume --input <file> --outdir <dir>
 # Use CLI defaults instead of orchestrator overrides
 python -m diaremot.cli run --input <file> --outdir <dir> \
   --vad-threshold 0.30 \
-  --speech-pad-sec 0.20 \
+  --vad-speech-pad-sec 0.20 \
   --ahc-distance-threshold 0.12
 ```
 

--- a/DOCUMENTATION_STATUS.md
+++ b/DOCUMENTATION_STATUS.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-**Task complete.** All documentation has been rewritten from ground truth source code analysis.
+**Status: In progress.** Key factual errors have been corrected using ground truth code review, but the full documentation set still needs expansion and polish.
 
 ## Files Updated
 
@@ -44,7 +44,7 @@ All values verified against actual source code:
 
 ## Current State
 
-**Docs are NOT complete yet.** Need to rebuild with full detail while keeping corrections. The oversimplified versions I created are missing:
+The documentation rewrite remains **incomplete**. To finish the effort we still need to capture the following:
 
 - Detailed stage parameter descriptions
 - Model asset locations and fallback strategies
@@ -54,4 +54,4 @@ All values verified against actual source code:
 - Development workflows
 - Reporting templates
 
-Working on comprehensive rebuild now...
+Next action: build out these sections while preserving the verified corrections above.

--- a/DOCUMENTATION_UPDATES.md
+++ b/DOCUMENTATION_UPDATES.md
@@ -1,6 +1,6 @@
 # Documentation & Testing Updates - 2025-10-04
 
-## Changes Made
+## Completed Work
 
 ### 1. Fixed Paralinguistics Fallback Bug
 **File:** `src/diaremot/pipeline/orchestrator.py`
@@ -18,26 +18,31 @@
 
 **Impact:** Prevents schema violations when Praat-Parselmouth unavailable
 
+### 2. Standardized CLI Documentation & VAD Overrides
+**Files:** `README.md`, `README_NEW.md`, `CLAUDE.md`, `AI_INDEX.yaml`, `AGENTS.md`
+
+**Issue:** Documentation listed non-existent flags (`--asr-model`, `--speech-pad-sec`) and omitted orchestrator VAD auto-tuning values.
+
+**Fixes:**
+- Added README section detailing auto-tune defaults and explicit CLI overrides (`--vad-threshold`, `--vad-min-speech-sec`, `--vad-min-silence-sec`, `--vad-speech-pad-sec`).
+- Updated CLI references to use canonical flags (`--whisper-model`, `--vad-speech-pad-sec`).
+- Documented the 14 mandatory paralinguistics metrics in AGENTS instructions.
+
+**Impact:** Eliminates conflicting guidance and ensures operators can reliably revert to CLI defaults.
+
+## Outstanding Updates
+
+### Test Coverage Follow-up
+**Status:** Pending review
+
+- Confirm `tests/test_orchestrator_para_fallback.py` remains aligned with the latest schema changes and run it in CI.
+- Add integration coverage that forces the paralinguistics module to fail to validate CSV completeness end-to-end.
+
 ---
 
-### 2. Documented Adaptive VAD Tuning
-**File:** `README.md`
+## Historical Context
 
-**Added section:**
-```markdown
-- **Adaptive VAD tuning**: Pipeline automatically relaxes VAD thresholds for soft-speech scenarios:
-  - `vad_threshold`: 0.22 (relaxed from CLI default 0.30)
-  - `vad_min_speech_sec`: 0.40s (relaxed from 0.80s)
-  - `vad_min_silence_sec`: 0.40s (relaxed from 0.80s)
-  - `speech_pad_sec`: 0.15s (relaxed from 0.20s)
-- Override adaptive tuning via CLI: `--vad-threshold 0.3 --vad-min-speech-sec 0.8`
-```
-
-**Rationale:** Users were unaware orchestrator overrides VAD defaults to prevent energy-VAD fallback
-
----
-
-### 3. Added Unit Tests
+### Added Unit Tests (2025-10-04)
 **File:** `tests/test_orchestrator_para_fallback.py`
 
 **Test coverage:**
@@ -53,22 +58,10 @@ cd D:\diaremot\diaremot2-ai
 pytest tests/test_orchestrator_para_fallback.py -v
 ```
 
----
-
-### 4. Updated AGENTS.md
-**Added missing paralinguistics metrics:**
-- `duration_s`
-- `words`
-- `pause_ratio`
-
-**Updated timestamp:** 2025-10-04
-
----
-
 ## Verification Checklist
 
 - [x] Orchestrator fallback populates all SEGMENT_COLUMNS fields
-- [x] README documents adaptive VAD tuning
+- [x] README documents adaptive VAD overrides (0.35/0.8/0.8/0.10)
 - [x] Unit tests written for fallback path
 - [ ] **TODO:** Run pytest to verify tests pass
 - [ ] **TODO:** Test actual fallback with broken para module
@@ -96,7 +89,7 @@ pytest tests/test_orchestrator_para_fallback.py -v
 
 ---
 
-## Files Modified
+## Historical Files Modified (to be reconfirmed)
 
 1. `src/diaremot/pipeline/orchestrator.py` (+6 lines)
 2. `README.md` (+7 lines)

--- a/README.md
+++ b/README.md
@@ -103,6 +103,29 @@ Notes
 python -m diaremot.pipeline.audio_pipeline_core --verify_deps --strict_dependency_versions
 ```
 
+## Adaptive VAD Overrides (Orchestrator vs CLI)
+
+The orchestrator tightens diarization defaults when the CLI does **not** specify overrides. This reduces micro-segments in noisy recordings but can be relaxed via flags:
+
+| Parameter | CLI default | Orchestrator auto-tune | Override flag |
+|-----------|-------------|------------------------|---------------|
+| `vad_threshold` | 0.30 | **0.35** | `--vad-threshold` |
+| `vad_min_speech_sec` | 0.80 s | **0.80 s** (unchanged) | `--vad-min-speech-sec` |
+| `vad_min_silence_sec` | 0.80 s | **0.80 s** (unchanged) | `--vad-min-silence-sec` |
+| `vad_speech_pad_sec` | 0.20 s | **0.10 s** | `--vad-speech-pad-sec` |
+
+To keep the original CLI defaults, supply all four flags explicitly:
+
+```bash
+python -m diaremot.cli run --input data/sample.wav --outdir outputs/ \
+  --vad-threshold 0.30 \
+  --vad-min-speech-sec 0.80 \
+  --vad-min-silence-sec 0.80 \
+  --vad-speech-pad-sec 0.20
+```
+
+All values verified in `src/diaremot/pipeline/orchestrator.py::_init_components` (strict overrides applied only when a value is absent from the merged config).
+
 Troubleshooting
 - Torch `_C` import errors: ensure you used the venv created here; the code lazily imports heavy backends now.
 - Librosa lazy_loader error: the code imports `librosa` module and uses `librosa.func` style, which avoids the issue. Ensure you’re on the pinned versions from `requirements.txt`.

--- a/README_NEW.md
+++ b/README_NEW.md
@@ -186,7 +186,7 @@ ahc_distance_threshold = 0.15  # Looser (prevent speaker fragmentation)
 # Use CLI defaults instead of orchestrator tuning
 python -m diaremot.cli run -i audio.wav -o outputs/ \
   --vad-threshold 0.30 \
-  --speech-pad-sec 0.20 \
+  --vad-speech-pad-sec 0.20 \
   --ahc-distance-threshold 0.12
 ```
 

--- a/connector/app.py
+++ b/connector/app.py
@@ -1,39 +1,112 @@
-import json
+from __future__ import annotations
+
 import os
 import pathlib
-import shlex
-import subprocess
+import tempfile
 import uuid
+from typing import Any
+from urllib.parse import urlparse
+from urllib.request import urlopen
 
 from fastapi import BackgroundTasks, FastAPI, Header, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+from diaremot.pipeline.orchestrator import run_pipeline as orchestrator_run
+
 
 app = FastAPI()
 API_KEY = os.getenv("X_API_KEY", "dev-key")
 
-class RunRequest(BaseModel):
-    audio_url: str | None = None
-    params: dict = {}
 
-def run_pipeline(audio_url: str | None, params: dict, outdir: str):
-    pathlib.Path(outdir).mkdir(parents=True, exist_ok=True)
-    # TODO: swap in your real CLI; this is a stub
-    cmd = f'python transcribe.py --audio "{audio_url or ""}" --outdir "{outdir}"'
-    if params:
-        cmd += " --params " + shlex.quote(json.dumps(params))
-    subprocess.run(cmd, shell=True, check=False)
+class RunRequest(BaseModel):
+    """Payload accepted by the `/run` endpoint."""
+
+    audio_url: str | None = None
+    params: dict[str, Any] = Field(default_factory=dict)
+
+
+def _resolve_audio_source(audio_url: str | None, workdir: pathlib.Path) -> pathlib.Path:
+    if not audio_url:
+        raise HTTPException(status_code=400, detail="audio_url is required")
+
+    parsed = urlparse(audio_url)
+    if parsed.scheme in {"http", "https"}:
+        suffix = pathlib.Path(parsed.path).suffix or ".wav"
+        tmp_handle = tempfile.NamedTemporaryFile(
+            suffix=suffix, delete=False, dir=str(workdir)
+        )
+        tmp_path = pathlib.Path(tmp_handle.name)
+        try:
+            with urlopen(audio_url) as response, tmp_handle:
+                tmp_handle.write(response.read())
+                tmp_handle.flush()
+        except Exception as exc:  # pragma: no cover - network failure
+            tmp_path.unlink(missing_ok=True)
+            raise HTTPException(status_code=502, detail=f"Failed to download audio: {exc}")
+        return tmp_path
+
+    source_path = pathlib.Path(audio_url).expanduser()
+    if not source_path.exists():
+        raise HTTPException(status_code=404, detail=f"Audio file not found: {audio_url}")
+    return source_path.resolve()
+
+
+def _prepare_config(overrides: dict[str, Any]) -> dict[str, Any] | None:
+    if not overrides:
+        return None
+
+    def _normalise_key(key: str) -> str:
+        key = key.strip().lower().replace("-", "_")
+        if key == "asr_compute_type":
+            return "compute_type"
+        if key == "asr_cpu_threads":
+            return "cpu_threads"
+        if key == "chunk_enabled":
+            return "auto_chunk_enabled"
+        if key == "speech_pad_sec":  # legacy clients
+            return "vad_speech_pad_sec"
+        return key
+
+    normalised: dict[str, Any] = {}
+    for raw_key, value in overrides.items():
+        if value is None:
+            continue
+        normalised[_normalise_key(str(raw_key))] = value
+
+    return normalised or None
+
+
+def run_pipeline(audio_url: str | None, params: dict[str, Any], outdir: str) -> None:
+    out_path = pathlib.Path(outdir)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    audio_path = _resolve_audio_source(audio_url, out_path)
+    config = _prepare_config(params)
+
+    try:
+        orchestrator_run(str(audio_path), str(out_path), config=config)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
 
 def ensure_auth(x_api_key: str | None):
     if not x_api_key or x_api_key != API_KEY:
         raise HTTPException(status_code=401, detail="Invalid API key")
 
+
 @app.post("/run")
-def run_job(req: RunRequest, bg: BackgroundTasks, x_api_key: str | None = Header(None, alias="x-api-key")):
+def run_job(
+    req: RunRequest,
+    bg: BackgroundTasks,
+    x_api_key: str | None = Header(None, alias="x-api-key"),
+):
     ensure_auth(x_api_key)
     job_id = str(uuid.uuid4())
-    outdir = str(pathlib.Path("runs") / job_id)
-    bg.add_task(run_pipeline, req.audio_url, req.params, outdir)
+    outdir = pathlib.Path("runs") / job_id
+    outdir.mkdir(parents=True, exist_ok=True)
+    bg.add_task(run_pipeline, req.audio_url, req.params, str(outdir))
     return {"job_id": job_id, "status": "queued"}
+
 
 @app.get("/status/{job_id}")
 def status(job_id: str, x_api_key: str | None = Header(None, alias="x-api-key")):
@@ -42,12 +115,17 @@ def status(job_id: str, x_api_key: str | None = Header(None, alias="x-api-key"))
     done = (outdir / "summary.html").exists()
     return {"job_id": job_id, "status": "done" if done else "running"}
 
+
 @app.get("/results/{job_id}")
 def results(job_id: str, x_api_key: str | None = Header(None, alias="x-api-key")):
     ensure_auth(x_api_key)
     base = f"/static/{job_id}"
-    return {"job_id": job_id, "files": {
-        "csv": f"{base}/diarized_transcript_with_emotion.csv",
-        "summary_html": f"{base}/summary.html",
-        "speakers": f"{base}/speakers_summary.csv"
-    }}
+    return {
+        "job_id": job_id,
+        "files": {
+            "csv": f"{base}/diarized_transcript_with_emotion.csv",
+            "summary_html": f"{base}/summary.html",
+            "speakers": f"{base}/speakers_summary.csv",
+        },
+    }
+


### PR DESCRIPTION
## Summary
- document the orchestrator’s adaptive VAD defaults and standardise CLI flag references across README, AI index, AGENTS, CLAUDE, and the audit report
- refresh the documentation log to record the completed CLI/VAD work
- replace the connector FastAPI stub with an orchestrator-backed runner that validates audio sources, normalises overrides, and queues jobs in place

## Testing
- python -m compileall connector/app.py

------
https://chatgpt.com/codex/tasks/task_e_68e446c905a4832eb67702ce01c019ed