### PR TITLE
Harden package __init__ lazy exports

### DIFF
--- a/src/diaremot/__init__.py
+++ b/src/diaremot/__init__.py
@@ -31,6 +31,7 @@ _LEGACY_MODULE_ALIASES = {
     "speaker_diarization": "diaremot.pipeline.speaker_diarization",
     "transcription_module": "diaremot.pipeline.transcription_module",
     "validate_system_complete": "diaremot.pipeline.validate_system_complete",
+    "emotion_analysis": "diaremot.affect.emotion_analysis",
     "emotion_analyzer": "diaremot.affect.emotion_analyzer",
     "intent_defaults": "diaremot.affect.intent_defaults",
     "paralinguistics": "diaremot.affect.paralinguistics",

--- a/src/diaremot/affect/__init__.py
+++ b/src/diaremot/affect/__init__.py
@@ -1,8 +1,32 @@
 """Affect analysis modules (emotion, intent, paralinguistics)."""
 
-__all__ = [
-    "emotion_analyzer",
-    "intent_defaults",
-    "paralinguistics",
-    "sed_panns",
-]
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+
+_SUBMODULES: dict[str, str] = {
+    "emotion_analysis": "diaremot.affect.emotion_analysis",
+    "emotion_analyzer": "diaremot.affect.emotion_analyzer",
+    "intent_defaults": "diaremot.affect.intent_defaults",
+    "paralinguistics": "diaremot.affect.paralinguistics",
+    "sed_panns": "diaremot.affect.sed_panns",
+}
+
+__all__ = list(_SUBMODULES)
+
+
+def __getattr__(name: str) -> ModuleType:
+    """Lazily import affect submodules when accessed via the package."""
+
+    if name in _SUBMODULES:
+        module = import_module(_SUBMODULES[name])
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Expose lazy submodules through :func:`dir`."""
+
+    return sorted(list(globals().keys()) + list(_SUBMODULES.keys()))

--- a/src/diaremot/io/__init__.py
+++ b/src/diaremot/io/__init__.py
@@ -1,7 +1,26 @@
 """Persistence and model I/O helpers."""
 
-__all__ = [
-    "download_utils",
-    "onnx_utils",
-    "speaker_registry_manager",
-]
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+
+_SUBMODULES: dict[str, str] = {
+    "download_utils": "diaremot.io.download_utils",
+    "onnx_utils": "diaremot.io.onnx_utils",
+    "speaker_registry_manager": "diaremot.io.speaker_registry_manager",
+}
+
+__all__ = list(_SUBMODULES)
+
+
+def __getattr__(name: str) -> ModuleType:
+    if name in _SUBMODULES:
+        module = import_module(_SUBMODULES[name])
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(list(globals().keys()) + list(_SUBMODULES.keys()))

--- a/src/diaremot/pipeline/__init__.py
+++ b/src/diaremot/pipeline/__init__.py
@@ -1,19 +1,38 @@
 """Core pipeline orchestration and helper components."""
 
-__all__ = [
-    "audio_pipeline_core",
-    "audio_preprocessing",
-    "cli_entry",
-    "cpu_optimized_diarizer",
-    "config",
-    "logging_utils",
-    "orchestrator",
-    "outputs",
-    "pipeline_checkpoint_system",
-    "pipeline_diagnostic",
-    "pipeline_healthcheck",
-    "run_pipeline",
-    "speaker_diarization",
-    "transcription_module",
-    "validate_system_complete",
-]
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+
+_SUBMODULES: dict[str, str] = {
+    "audio_pipeline_core": "diaremot.pipeline.audio_pipeline_core",
+    "audio_preprocessing": "diaremot.pipeline.audio_preprocessing",
+    "cli_entry": "diaremot.pipeline.cli_entry",
+    "cpu_optimized_diarizer": "diaremot.pipeline.cpu_optimized_diarizer",
+    "config": "diaremot.pipeline.config",
+    "logging_utils": "diaremot.pipeline.logging_utils",
+    "orchestrator": "diaremot.pipeline.orchestrator",
+    "outputs": "diaremot.pipeline.outputs",
+    "pipeline_checkpoint_system": "diaremot.pipeline.pipeline_checkpoint_system",
+    "pipeline_diagnostic": "diaremot.pipeline.pipeline_diagnostic",
+    "pipeline_healthcheck": "diaremot.pipeline.pipeline_healthcheck",
+    "run_pipeline": "diaremot.pipeline.run_pipeline",
+    "speaker_diarization": "diaremot.pipeline.speaker_diarization",
+    "transcription_module": "diaremot.pipeline.transcription_module",
+    "validate_system_complete": "diaremot.pipeline.validate_system_complete",
+}
+
+__all__ = list(_SUBMODULES)
+
+
+def __getattr__(name: str) -> ModuleType:
+    if name in _SUBMODULES:
+        module = import_module(_SUBMODULES[name])
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(list(globals().keys()) + list(_SUBMODULES.keys()))

--- a/src/diaremot/summaries/__init__.py
+++ b/src/diaremot/summaries/__init__.py
@@ -1,8 +1,27 @@
 """Summary generation utilities and conversation analytics."""
 
-__all__ = [
-    "conversation_analysis",
-    "html_summary_generator",
-    "pdf_summary_generator",
-    "speakers_summary_builder",
-]
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+
+_SUBMODULES: dict[str, str] = {
+    "conversation_analysis": "diaremot.summaries.conversation_analysis",
+    "html_summary_generator": "diaremot.summaries.html_summary_generator",
+    "pdf_summary_generator": "diaremot.summaries.pdf_summary_generator",
+    "speakers_summary_builder": "diaremot.summaries.speakers_summary_builder",
+}
+
+__all__ = list(_SUBMODULES)
+
+
+def __getattr__(name: str) -> ModuleType:
+    if name in _SUBMODULES:
+        module = import_module(_SUBMODULES[name])
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(list(globals().keys()) + list(_SUBMODULES.keys()))

--- a/tests/test_emotion_imports.py
+++ b/tests/test_emotion_imports.py
@@ -1,0 +1,12 @@
+"""Regression tests for emotion analysis import compatibility."""
+
+def test_affect_package_exposes_emotion_analysis():
+    from diaremot.affect import emotion_analysis
+
+    assert hasattr(emotion_analysis, "EmotionAnalyzer")
+
+
+def test_root_package_legacy_emotion_analysis_alias():
+    from diaremot import emotion_analysis
+
+    assert hasattr(emotion_analysis, "EmotionAnalyzer")

--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -1,0 +1,33 @@
+"""Regression coverage for package-level __init__ exports."""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+
+import pytest
+
+PACKAGE_EXPORTS = [
+    "diaremot.affect",
+    "diaremot.io",
+    "diaremot.pipeline",
+    "diaremot.summaries",
+]
+
+
+@pytest.mark.parametrize("package_name", PACKAGE_EXPORTS)
+def test_star_import_populates_all(package_name: str) -> None:
+    module = importlib.import_module(package_name)
+    exported = getattr(module, "__all__", ())
+
+    namespace: dict[str, object] = {}
+    exec(f"from {package_name} import *", namespace)
+
+    for name in exported:
+        assert name in namespace, f"{package_name} missing {name} in star import"
+        attr = getattr(module, name)
+        if isinstance(attr, ModuleType):
+            submodule = importlib.import_module(f"{package_name}.{name}")
+            assert (
+                attr is submodule
+            ), f"{package_name}.{name} should resolve to its submodule"


### PR DESCRIPTION
## Summary
- add lazy import maps to the affect, io, pipeline, and summaries packages so their __all__ entries resolve to real submodules
- expose custom __dir__ helpers that surface lazily imported entries for interactive discovery
- add regression coverage asserting star imports populate every exported submodule

## Testing
- pytest tests/test_emotion_imports.py tests/test_package_exports.py

------
https://chatgpt.com/codex/tasks/task_e_68e57114c2e8832e82b216fb887648f0