### PR TITLE
Fix CLI argument formatting and guard against merge markers

### DIFF
--- a/src/diaremot/pipeline/cli_entry.py
+++ b/src/diaremot/pipeline/cli_entry.py
@@ -90,7 +90,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--affect-backend",
         default="onnx",
-            choices=["auto", "onnx"],
+        choices=["auto", "onnx"],
         help="Backend for affect analysis",
     )
     parser.add_argument(
@@ -203,8 +203,8 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--vad-backend",
-            choices=["auto", "onnx"],
         default="auto",
+        choices=["auto", "onnx"],
         help="Preferred Silero VAD backend",
     )
     parser.add_argument(

--- a/tests/test_no_merge_conflicts.py
+++ b/tests/test_no_merge_conflicts.py
@@ -1,0 +1,34 @@
+"""Regression guard to catch unresolved merge markers in source files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+CONFLICT_MARKERS = ("<<<<<<<", "=======", ">>>>>>>")
+
+
+def _iter_python_sources() -> list[Path]:
+    roots = (Path("src"), Path("tests"))
+    files: list[Path] = []
+    for root in roots:
+        if not root.exists():
+            continue
+        files.extend(sorted(root.rglob("*.py")))
+    return files
+
+
+@pytest.mark.parametrize("path", _iter_python_sources(), ids=lambda p: str(p))
+def test_python_files_do_not_contain_merge_conflict_markers(path: Path) -> None:
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    lines = text.splitlines()
+    for raw_line in lines:
+        stripped = raw_line.lstrip()
+        if stripped.startswith(CONFLICT_MARKERS[0]):
+            pytest.fail(f"Found merge conflict marker '<<<<<<<' in {path}")
+        if stripped.startswith(CONFLICT_MARKERS[1]) and stripped.strip() == CONFLICT_MARKERS[1]:
+            pytest.fail(f"Found merge conflict marker '=======' in {path}")
+        if stripped.startswith(CONFLICT_MARKERS[2]):
+            pytest.fail(f"Found merge conflict marker '>>>>>>>' in {path}")


### PR DESCRIPTION
## Summary
- fix the CLI argument definitions that still showed merge-conflict indentation
- add a regression test that scans Python sources for unresolved merge conflict markers

## Testing
- PYTHONPATH=src pytest tests/test_no_merge_conflicts.py

------
https://chatgpt.com/codex/tasks/task_e_68e574098240832e800dcdb1f24d9ae8