### PR TITLE
Fix CLI enable_sed override wiring

### DIFF
--- a/src/diaremot/cli.py
+++ b/src/diaremot/cli.py
@@ -168,6 +168,7 @@ def _common_options(**kwargs: Any) -> dict[str, Any]:
         "temperature": kwargs.get("temperature"),
         "no_speech_threshold": kwargs.get("no_speech_threshold"),
         "noise_reduction": kwargs.get("noise_reduction"),
+        "enable_sed": kwargs.get("sed_enabled"),
         "auto_chunk_enabled": kwargs.get("chunk_enabled"),
         "chunk_threshold_minutes": kwargs.get("chunk_threshold_minutes"),
         "chunk_size_minutes": kwargs.get("chunk_size_minutes"),
@@ -263,6 +264,11 @@ def run(
         help="Enable gentle noise reduction.",
         is_flag=True,
     ),
+    enable_sed: bool = typer.Option(
+        True,
+        "--enable-sed/--disable-sed",
+        help="Toggle background sound event detection stage.",
+    ),
     chunk_enabled: Optional[bool] = typer.Option(
         None,
         "--chunk-enabled",
@@ -331,6 +337,7 @@ def run(
         vad_min_silence_sec=vad_min_silence_sec,
         vad_speech_pad_sec=vad_speech_pad_sec,
         vad_backend=vad_backend,
+        sed_enabled=enable_sed,
         disable_energy_vad_fallback=disable_energy_vad_fallback,
         energy_gate_db=energy_gate_db,
         energy_hop_sec=energy_hop_sec,
@@ -416,6 +423,11 @@ def resume(
         help="Enable gentle noise reduction.",
         is_flag=True,
     ),
+    enable_sed: bool = typer.Option(
+        True,
+        "--enable-sed/--disable-sed",
+        help="Toggle background sound event detection stage.",
+    ),
     chunk_enabled: Optional[bool] = typer.Option(
         None,
         "--chunk-enabled",
@@ -478,6 +490,7 @@ def resume(
         vad_min_silence_sec=vad_min_silence_sec,
         vad_speech_pad_sec=vad_speech_pad_sec,
         vad_backend=vad_backend,
+        sed_enabled=enable_sed,
         disable_energy_vad_fallback=disable_energy_vad_fallback,
         energy_gate_db=energy_gate_db,
         energy_hop_sec=energy_hop_sec,

--- a/src/diaremot/pipeline/cli_entry.py
+++ b/src/diaremot/pipeline/cli_entry.py
@@ -127,6 +127,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="Enable spectral subtraction noise reduction",
     )
     parser.add_argument(
+        "--enable-sed",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable background sound event detection (use --no-enable-sed to skip)",
+    )
+    parser.add_argument(
         "--chunk-enabled",
         action=argparse.BooleanOptionalAction,
         default=True,
@@ -261,6 +267,7 @@ def _args_to_config(args: argparse.Namespace, *, ignore_tx_cache: bool) -> dict[
         "temperature": args.temperature,
         "no_speech_threshold": args.no_speech_threshold,
         "noise_reduction": bool(args.noise_reduction),
+        "enable_sed": bool(args.enable_sed),
         "auto_chunk_enabled": bool(args.chunk_enabled),
         "chunk_threshold_minutes": float(args.chunk_threshold_minutes),
         "chunk_size_minutes": float(args.chunk_size_minutes),

--- a/src/diaremot/pipeline/config.py
+++ b/src/diaremot/pipeline/config.py
@@ -71,6 +71,7 @@ class PipelineConfig:
     temperature: float = 0.0
     no_speech_threshold: float = 0.50
     noise_reduction: bool = False
+    enable_sed: bool = True
     auto_chunk_enabled: bool = True
     chunk_threshold_minutes: float = 60.0
     chunk_size_minutes: float = 20.0
@@ -156,6 +157,13 @@ class PipelineConfig:
         self._validate_positive_float("chunk_threshold_minutes", self.chunk_threshold_minutes)
         self._validate_positive_float("chunk_size_minutes", self.chunk_size_minutes)
         _ensure_numeric_range("chunk_overlap_seconds", self.chunk_overlap_seconds, ge=0.0)
+        if isinstance(self.enable_sed, bool):
+            pass
+        elif isinstance(self.enable_sed, (int, float)):
+            self.enable_sed = bool(self.enable_sed)
+        else:
+            raise ValueError("enable_sed must be a boolean value")
+        self.enable_sed = bool(self.enable_sed)
         _ensure_numeric_range("vad_threshold", self.vad_threshold, ge=0.0, le=1.0)
         _ensure_numeric_range("temperature", self.temperature, ge=0.0, le=1.0)
         _ensure_numeric_range("no_speech_threshold", self.no_speech_threshold, ge=0.0, le=1.0)


### PR DESCRIPTION
## Summary
- stop passing duplicate enable_sed keywords from the Typer CLI by renaming the override

## Testing
- pytest tests/test_pipeline_stages_module.py

------
https://chatgpt.com/codex/tasks/task_e_68e5f0c5fbf4832e82e0bb864b57841f